### PR TITLE
Add prop for unique report names, add support for running non unique list of tests

### DIFF
--- a/testah-junit/build.gradle
+++ b/testah-junit/build.gradle
@@ -12,7 +12,7 @@ apply plugin: 'jacoco'
 sourceCompatibility = 1.8
 group = 'org.testah'
 
-version = '1.0.1'
+version = '1.1.0'
 
 buildscript {
     repositories {

--- a/testah-junit/src/main/java/org/testah/client/dto/TestCaseDto.java
+++ b/testah-junit/src/main/java/org/testah/client/dto/TestCaseDto.java
@@ -278,7 +278,7 @@ public class TestCaseDto {
 
     /**
      * Gets the assertion error.
-     * 
+     *
      * <p>throws Assertion Error for Errors in the steps
      */
     @JsonIgnore

--- a/testah-junit/src/main/java/org/testah/client/dto/TestPlanDto.java
+++ b/testah-junit/src/main/java/org/testah/client/dto/TestPlanDto.java
@@ -237,6 +237,7 @@ public class TestPlanDto extends AbstractDtoBase<TestPlanDto> {
 
     /**
      * Get test status enum.
+     *
      * @return test status enum
      */
     public TestStatus getStatusEnum() {

--- a/testah-junit/src/main/java/org/testah/driver/http/AbstractHttpWrapper.java
+++ b/testah-junit/src/main/java/org/testah/driver/http/AbstractHttpWrapper.java
@@ -1,12 +1,6 @@
 package org.testah.driver.http;
 
-import org.apache.http.Header;
-import org.apache.http.HeaderElement;
-import org.apache.http.HeaderElementIterator;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpHost;
-import org.apache.http.HttpRequest;
-import org.apache.http.HttpResponse;
+import org.apache.http.*;
 import org.apache.http.client.CookieStore;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.AuthSchemes;
@@ -46,11 +40,7 @@ import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.http.ssl.SSLContexts;
 import org.apache.http.util.EntityUtils;
 import org.testah.TS;
-import org.testah.driver.http.requests.AbstractRequestDto;
-import org.testah.driver.http.requests.DeleteRequestDto;
-import org.testah.driver.http.requests.GetRequestDto;
-import org.testah.driver.http.requests.PostRequestDto;
-import org.testah.driver.http.requests.PutRequestDto;
+import org.testah.driver.http.requests.*;
 import org.testah.driver.http.response.ResponseDto;
 import org.testah.framework.report.VerboseAsserts;
 import org.testah.framework.testPlan.AbstractTestPlan;

--- a/testah-junit/src/main/java/org/testah/driver/http/HttpAsynchWrapperV1.java
+++ b/testah-junit/src/main/java/org/testah/driver/http/HttpAsynchWrapperV1.java
@@ -48,7 +48,7 @@ public class HttpAsynchWrapperV1 extends AbstractHttpWrapper implements Closeabl
             if (null != getConnectionManager()) {
                 final ConnectingIOReactor ioReactor = new DefaultConnectingIOReactor();
                 final PoolingNHttpClientConnectionManager connManager = new PoolingNHttpClientConnectionManager(
-                    ioReactor);
+                        ioReactor);
                 connManager.setMaxTotal(100);
                 hcb.setConnectionManager(connManager);
             }
@@ -89,30 +89,30 @@ public class HttpAsynchWrapperV1 extends AbstractHttpWrapper implements Closeabl
             try {
                 getHttpAsyncClient().start();
                 final Future<HttpResponse> future = getHttpAsyncClient().execute(request.getHttpRequestBase(), context,
-                    new FutureCallback<HttpResponse>() {
+                        new FutureCallback<HttpResponse>() {
 
-                        public void completed(final HttpResponse response) {
-                            if (verbose) {
-                                final ResponseDto responseDto = getResponseDto(response, request);
-                                AbstractTestPlan.addStepAction(responseDto.createResponseInfoStep(true, true, 500));
+                            public void completed(final HttpResponse response) {
+                                if (verbose) {
+                                    final ResponseDto responseDto = getResponseDto(response, request);
+                                    AbstractTestPlan.addStepAction(responseDto.createResponseInfoStep(true, true, 500));
+                                }
                             }
-                        }
 
-                        public void failed(final Exception ex) {
-                            if (verbose) {
-                                AbstractTestPlan.addStepAction(StepAction.createInfo(
-                                    "ERROR - Issue with reques" + request.getHttpRequestBase().getRequestLine(),
-                                    ex.getMessage()));
+                            public void failed(final Exception ex) {
+                                if (verbose) {
+                                    AbstractTestPlan.addStepAction(StepAction.createInfo(
+                                            "ERROR - Issue with reques" + request.getHttpRequestBase().getRequestLine(),
+                                            ex.getMessage()));
+                                }
                             }
-                        }
 
-                        public void cancelled() {
-                            if (verbose) {
-                                AbstractTestPlan.addStepAction(StepAction.createInfo("Canceled Request",
-                                    request.getHttpRequestBase().getRequestLine().toString()));
+                            public void cancelled() {
+                                if (verbose) {
+                                    AbstractTestPlan.addStepAction(StepAction.createInfo("Canceled Request",
+                                            request.getHttpRequestBase().getRequestLine().toString()));
+                                }
                             }
-                        }
-                    });
+                        });
                 return future;
             } finally {
                 // need to complete try block, maybe move declaration of Future<HttpResponse> future = null out of try block
@@ -122,7 +122,7 @@ public class HttpAsynchWrapperV1 extends AbstractHttpWrapper implements Closeabl
             TS.log().error(e);
             if (!isIgnoreHttpError()) {
                 TS.asserts().equalsTo("Unexpeced Exception thrown from preformRequest in IHttpWrapper", "",
-                    e.getMessage());
+                        e.getMessage());
             }
             return null;
         }
@@ -171,12 +171,11 @@ public class HttpAsynchWrapperV1 extends AbstractHttpWrapper implements Closeabl
      * @throws Exception the exception
      */
     public ResponseDto getResponseDtoFromFuture(final Future<HttpResponse> response, final AbstractRequestDto<?> request)
-        throws Exception
-    {
+            throws Exception {
         if (null != response) {
             try {
                 TS.log().debug("Getting response from future, current done state is: " + response.isDone()
-                    + " will block until done.");
+                        + " will block until done.");
                 final HttpResponse responseFromFuture = response.get();
                 return getResponseDto(responseFromFuture, request);
             } catch (final Exception e) {

--- a/testah-junit/src/main/java/org/testah/driver/http/response/ResponseDto.java
+++ b/testah-junit/src/main/java/org/testah/driver/http/response/ResponseDto.java
@@ -1,7 +1,5 @@
 package org.testah.driver.http.response;
 
-import static org.apache.commons.lang.StringEscapeUtils.escapeHtml;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -22,6 +20,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
+
+import static org.apache.commons.lang.StringEscapeUtils.escapeHtml;
 
 /**
  * The Class ResponseDto.
@@ -131,7 +131,7 @@ public class ResponseDto extends AbstractDtoBase<ResponseDto> {
     public ResponseDto assertResponseBodyContains(final String expectedContents) {
         TS.asserts().notNull("assertResponseBodyContains", responseBody);
         TS.asserts().isTrue("assertResponseBodyContains responseBody[" + responseBody + "] expected to contain["
-            + expectedContents + "]", responseBody.contains(expectedContents));
+                + expectedContents + "]", responseBody.contains(expectedContents));
         return this;
     }
 
@@ -222,8 +222,7 @@ public class ResponseDto extends AbstractDtoBase<ResponseDto> {
      */
     public File saveToFile(final File downloadFile) throws IOException {
         try (
-            FileOutputStream fileOuputStream = new FileOutputStream(downloadFile))
-        {
+                FileOutputStream fileOuputStream = new FileOutputStream(downloadFile)) {
             fileOuputStream.write(this.getResponseBytes());
             return downloadFile;
         }
@@ -440,19 +439,18 @@ public class ResponseDto extends AbstractDtoBase<ResponseDto> {
      * @return the step action dto
      */
     public StepActionDto createResponseInfoStep(final boolean shortResponseBody, final boolean escapdeBody,
-                                                final int truncate)
-    {
+                                                final int truncate) {
         StepActionDto stepAction = null;
         if (shortResponseBody) {
             stepAction = StepAction
-                .createInfo(this.getRequestType() + " - Uri: " + getUrl(),
-                    "Status: " + getStatusCode() + " [ " + getStatusText() + " ]",
-                    StringUtils.abbreviate(getResponseBody(escapdeBody), truncate), false)
-                .setTestStepActionType(TestStepActionType.HTTP_REQUEST);
+                    .createInfo(this.getRequestType() + " - Uri: " + getUrl(),
+                            "Status: " + getStatusCode() + " [ " + getStatusText() + " ]",
+                            StringUtils.abbreviate(getResponseBody(escapdeBody), truncate), false)
+                    .setTestStepActionType(TestStepActionType.HTTP_REQUEST);
         } else {
             stepAction = StepAction.createInfo(this.getRequestType() + " - Uri: " + getUrl(),
-                "Status: " + getStatusCode() + " [ " + getStatusText() + " ]", getResponseBody(escapdeBody), false)
-                .setTestStepActionType(TestStepActionType.HTTP_REQUEST);
+                    "Status: " + getStatusCode() + " [ " + getStatusText() + " ]", getResponseBody(escapdeBody), false)
+                    .setTestStepActionType(TestStepActionType.HTTP_REQUEST);
 
         }
         print(shortResponseBody, truncate);
@@ -480,7 +478,7 @@ public class ResponseDto extends AbstractDtoBase<ResponseDto> {
      */
     public String toStringStatus() {
         return new StringBuilder("Uri:").append(getUrl()).append("\nStatus: ").append(statusCode).append(" [ ")
-            .append(statusText).append(" ]").toString();
+                .append(statusText).append(" ]").toString();
     }
 
     /**

--- a/testah-junit/src/main/java/org/testah/driver/web/browser/AbstractBrowser.java
+++ b/testah-junit/src/main/java/org/testah/driver/web/browser/AbstractBrowser.java
@@ -1,13 +1,7 @@
 package org.testah.driver.web.browser;
 
 import org.apache.commons.io.FileUtils;
-import org.openqa.selenium.By;
-import org.openqa.selenium.Dimension;
-import org.openqa.selenium.JavascriptExecutor;
-import org.openqa.selenium.OutputType;
-import org.openqa.selenium.TakesScreenshot;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
+import org.openqa.selenium.*;
 import org.openqa.selenium.remote.Augmenter;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;

--- a/testah-junit/src/main/java/org/testah/driver/web/browser/GoogleChromeBrowser.java
+++ b/testah-junit/src/main/java/org/testah/driver/web/browser/GoogleChromeBrowser.java
@@ -25,13 +25,7 @@ public class GoogleChromeBrowser extends AbstractBrowser<GoogleChromeBrowser> {
      */
     private ChromeDriverService service = null;
 
-    /*
-     * (non-Javadoc).
-     *
-     * @see
-     * org.testah.driver.web.browser.AbstractBrowser#getWebDriver(org.openqa.
-     * selenium.remote.DesiredCapabilities).
-     */
+
     public WebDriver getWebDriver(final DesiredCapabilities capabilities) {
         if (null == service) {
             return new ChromeDriver(capabilities);

--- a/testah-junit/src/main/java/org/testah/driver/web/element/AbstractWebElementWrapper.java
+++ b/testah-junit/src/main/java/org/testah/driver/web/element/AbstractWebElementWrapper.java
@@ -81,8 +81,7 @@ public abstract class AbstractWebElementWrapper {
      * @return the abstract web element wrapper
      */
     public AbstractWebElementWrapper assertAttributeValue(final String attributeName,
-                                                          final String attributeExpectedValue)
-    {
+                                                          final String attributeExpectedValue) {
         TS.asserts().equalsTo("assertAttributeValue", attributeExpectedValue, getAttribute(attributeName));
         return getSelf();
     }
@@ -218,7 +217,7 @@ public abstract class AbstractWebElementWrapper {
     public boolean elementIsOk(final String activity, final boolean autoReport) {
         if (null == getDriverWebElement()) {
             final String msg = "Unable to preform activity[" + activity + "], webelement[" + by
-                + "] is null and not availible.";
+                    + "] is null and not availible.";
             if (autoReport) {
                 TS.asserts().notNull(msg, webElement);
             } else {
@@ -389,8 +388,7 @@ public abstract class AbstractWebElementWrapper {
      * @return the elements with in
      */
     public List<AbstractWebElementWrapper> getElementsWithIn(final By locator, final boolean noWait,
-                                                             final boolean autoAssert)
-    {
+                                                             final boolean autoAssert) {
         assertFound();
         String error = "";
         for (int count = 1; count <= timeout; count++) {
@@ -407,7 +405,7 @@ public abstract class AbstractWebElementWrapper {
         }
         if (autoAssert) {
             TS.asserts().equalsTo("Expected to find WebElements within Element[" + this.by + "] uisng By[" + locator
-                + "] - error: " + error, true, false);
+                    + "] - error: " + error, true, false);
         }
         return new ArrayList<>();
     }
@@ -441,8 +439,7 @@ public abstract class AbstractWebElementWrapper {
      * @return the element with in
      */
     public AbstractWebElementWrapper getElementWithIn(final By locator, final boolean noWait,
-                                                      final boolean autoAssert)
-    {
+                                                      final boolean autoAssert) {
         assertFound();
         String error = "";
         for (int count = 1; count <= timeout; count++) {
@@ -459,7 +456,7 @@ public abstract class AbstractWebElementWrapper {
         }
         if (autoAssert) {
             TS.asserts().equalsTo("Expected to find WebElements within Element[" + this.by + "] uisng By[" + locator
-                + "] - error: " + error, true, false);
+                    + "] - error: " + error, true, false);
         }
         return null;
     }
@@ -482,8 +479,7 @@ public abstract class AbstractWebElementWrapper {
      * @return the list of webelements wrapped
      */
     public List<AbstractWebElementWrapper> getListOfWebelementsWrapped(final By locator,
-                                                                       final List<WebElement> webElements)
-    {
+                                                                       final List<WebElement> webElements) {
         final List<AbstractWebElementWrapper> lst = new ArrayList<>();
         if (null != webElements) {
             for (final WebElement e : webElements) {
@@ -529,8 +525,7 @@ public abstract class AbstractWebElementWrapper {
         String rtn = null;
         if (elementIsOk("getText", isAutoReport())) {
             if (webElement.getTagName().equalsIgnoreCase("input")
-                || webElement.getTagName().equalsIgnoreCase("textarea"))
-            {
+                    || webElement.getTagName().equalsIgnoreCase("textarea")) {
                 rtn = webElement.getAttribute("value");
             } else {
                 rtn = webElement.getText();
@@ -775,8 +770,7 @@ public abstract class AbstractWebElementWrapper {
      * @return the abstract web element wrapper
      */
     public AbstractWebElementWrapper waitTillAttributeEquals(final String attributeName, final String value,
-                                                             final int timeout)
-    {
+                                                             final int timeout) {
         for (int count = 1; count <= timeout; count++) {
             if (verifytAttributeValue(attributeName, value)) {
                 break;
@@ -789,7 +783,7 @@ public abstract class AbstractWebElementWrapper {
     /**
      * Wait till gone will wait up to the timeout, default value pulled from Testah properties, for the element to no longer be found or be
      * displayed. Types of usecases where this would be called is if clicking a close button, and wait for it to go away before moving forward.
-     * 
+     *
      * <p>Once timeout is exceeded or the element is not found or not displated an assert will be triggered since this methods assumes you want it
      * to no longer to be found.
      *
@@ -802,7 +796,7 @@ public abstract class AbstractWebElementWrapper {
     /**
      * Wait till gone will wait up to the timeout for the element to no longer be found or be displayed. Types of usecases where this would be
      * called is if clicking a close button, and wait for it to go away before moving forward.
-     * 
+     *
      * <p>Once timeout is exceeded or the element is not found or not displated an assert will be triggered since this methods assumes you want it
      * to no longer to be found.
      *

--- a/testah-junit/src/main/java/org/testah/framework/annotations/KnownProblem.java
+++ b/testah-junit/src/main/java/org/testah/framework/annotations/KnownProblem.java
@@ -2,11 +2,7 @@ package org.testah.framework.annotations;
 
 import org.testah.client.enums.TypeOfKnown;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Inherited;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 /**
  * The Interface KnownProblem.

--- a/testah-junit/src/main/java/org/testah/framework/annotations/TestCase.java
+++ b/testah-junit/src/main/java/org/testah/framework/annotations/TestCase.java
@@ -2,11 +2,7 @@ package org.testah.framework.annotations;
 
 import org.testah.client.enums.TestType;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Inherited;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 /**
  * The Interface TestCase.

--- a/testah-junit/src/main/java/org/testah/framework/annotations/TestPlan.java
+++ b/testah-junit/src/main/java/org/testah/framework/annotations/TestPlan.java
@@ -2,11 +2,7 @@ package org.testah.framework.annotations;
 
 import org.testah.client.enums.TestType;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Inherited;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 /**
  * The Interface TestPlan.

--- a/testah-junit/src/main/java/org/testah/framework/cli/Cli.java
+++ b/testah-junit/src/main/java/org/testah/framework/cli/Cli.java
@@ -2,11 +2,7 @@ package org.testah.framework.cli;
 
 import net.sourceforge.argparse4j.ArgumentParsers;
 import net.sourceforge.argparse4j.impl.Arguments;
-import net.sourceforge.argparse4j.inf.ArgumentParser;
-import net.sourceforge.argparse4j.inf.ArgumentParserException;
-import net.sourceforge.argparse4j.inf.Namespace;
-import net.sourceforge.argparse4j.inf.Subparser;
-import net.sourceforge.argparse4j.inf.Subparsers;
+import net.sourceforge.argparse4j.inf.*;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.testah.TS;
@@ -56,7 +52,7 @@ public class Cli {
      * The Constant version.
      */
 
-    public static final String version = "1.0.1";
+    public static final String version = "1.1.0";
 
     /**
      * The Constant BAR_LONG.
@@ -250,8 +246,8 @@ public class Cli {
                         } else {
                             totalTestCases += result.getJunitResult().getRunCount();
                             totalTestCasesFailed += result.getJunitResult().getFailureCount();
-                            totalTestCasesPassed += result.getJunitResult().getRunCount() -
-                                    (result.getJunitResult().getFailureCount() + result.getJunitResult().getIgnoreCount());
+                            totalTestCasesPassed += result.getJunitResult().getRunCount()
+                                    - (result.getJunitResult().getFailureCount() + result.getJunitResult().getIgnoreCount());
                             totalTestCasesIgnored += result.getJunitResult().getIgnoreCount();
                         }
                     }

--- a/testah-junit/src/main/java/org/testah/framework/cli/Params.java
+++ b/testah-junit/src/main/java/org/testah/framework/cli/Params.java
@@ -324,6 +324,15 @@ public class Params {
     @Arg(dest = "autoOpenHtmlReport")
     private boolean autoOpenHtmlReport = true;
 
+
+    /**
+     * The unique Report Name.
+     */
+    @Comment(info = "Should the reports use unique names.  If the test report runner is used, it is on by default, "
+            + "else is false and will cause reports to get overridden each run.")
+    @Arg(dest = "uniqueReportName")
+    private boolean uniqueReportName = false;
+
     /**
      * The send json test data to service.
      */
@@ -1421,5 +1430,13 @@ public class Params {
 
     public void setTimeFormat(final String timeFormat) {
         this.timeFormat = timeFormat;
+    }
+
+    public boolean isUniqueReportName() {
+        return uniqueReportName;
+    }
+
+    public void setUniqueReportName(final boolean uniqueReportName) {
+        this.uniqueReportName = uniqueReportName;
     }
 }

--- a/testah-junit/src/main/java/org/testah/framework/cli/TestFilter.java
+++ b/testah-junit/src/main/java/org/testah/framework/cli/TestFilter.java
@@ -15,11 +15,7 @@ import java.io.File;
 import java.io.IOException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
 import static org.apache.commons.lang3.StringUtils.trimToEmpty;

--- a/testah-junit/src/main/java/org/testah/framework/dto/StepAction.java
+++ b/testah-junit/src/main/java/org/testah/framework/dto/StepAction.java
@@ -79,8 +79,7 @@ public class StepAction extends StepActionDto {
      * @return the step action
      */
     public static StepAction createAssertResult(final String message, final Boolean status, final String assertMethod,
-                                                final Object expected, final Object actual, final Throwable exception)
-    {
+                                                final Object expected, final Object actual, final Throwable exception) {
         final StepAction step = new StepAction();
         step.setActionName(assertMethod);
         step.setMessage1(message);
@@ -94,7 +93,7 @@ public class StepAction extends StepActionDto {
             step.setHtmlSnapShotPath(TS.browser().takeHtmlSnapshot());
         }
         TS.log().debug(TestStepActionType.ASSERT + "[" + assertMethod + "] - " + status + " - " + message + " - expected[" + expected
-            + "] actual[" + actual + "]");
+                + "] actual[" + actual + "]");
         if (null != step.getExceptionString()) {
             TS.log().trace("Exception Related to above Assert\n" + step.getExceptionString());
         }
@@ -113,8 +112,7 @@ public class StepAction extends StepActionDto {
      * @return the step action
      */
     public static StepAction createVerifyResult(final String message, final Boolean status, final String assertMethod,
-                                                final Object expected, final Object actual, final Throwable exception)
-    {
+                                                final Object expected, final Object actual, final Throwable exception) {
         final StepAction step = new StepAction();
         step.setActionName(assertMethod);
         step.setMessage1(message + " - " + status);
@@ -125,7 +123,7 @@ public class StepAction extends StepActionDto {
         step.setTestStepActionType(TestStepActionType.VERIFY);
 
         TS.log().debug(TestStepActionType.VERIFY + "[" + assertMethod + "] - " + status + " - " + message + " - expected[" + expected
-            + "] actual[" + actual + "]");
+                + "] actual[" + actual + "]");
         return step;
     }
 
@@ -160,8 +158,7 @@ public class StepAction extends StepActionDto {
      * @return the step action
      */
     public static StepAction createInfo(final String message1, final String message2, final String message3,
-                                        final boolean autoLog)
-    {
+                                        final boolean autoLog) {
         return createInfo(message1, message2, message3, autoLog, false);
     }
 
@@ -176,8 +173,7 @@ public class StepAction extends StepActionDto {
      * @return the step action
      */
     public static StepAction createInfo(final String message1, final String message2, final String message3,
-                                        final boolean autoLog, final boolean takeSnapShot)
-    {
+                                        final boolean autoLog, final boolean takeSnapShot) {
         final StepAction step = new StepAction();
         step.setMessage1(message1);
         step.setMessage2(message2);

--- a/testah-junit/src/main/java/org/testah/framework/dto/TestDtoHelper.java
+++ b/testah-junit/src/main/java/org/testah/framework/dto/TestDtoHelper.java
@@ -41,8 +41,7 @@ public class TestDtoHelper {
      * @return the test plan dto
      */
     public static TestPlanDto fill(TestPlanDto testPlanToFill, final TestPlan fillFromTestPlan,
-                                   final KnownProblem knownProblemFillFrom)
-    {
+                                   final KnownProblem knownProblemFillFrom) {
         if (null == testPlanToFill) {
             testPlanToFill = new TestPlanDto();
         }
@@ -94,8 +93,7 @@ public class TestDtoHelper {
      * @return the test case dto
      */
     public static TestCaseDto fill(TestCaseDto testCaseToFill, final TestCase fillFromTestCase,
-                                   final KnownProblem knownProblemFillFrom, final TestPlan tpMeta)
-    {
+                                   final KnownProblem knownProblemFillFrom, final TestPlan tpMeta) {
         if (null == testCaseToFill) {
             testCaseToFill = new TestCaseDto();
         }
@@ -168,8 +166,7 @@ public class TestDtoHelper {
      * @return the test plan dto
      */
     public static TestPlanDto createTestPlanDto(final Description desc, final TestPlan meta,
-                                                final KnownProblem knownProblemFillFrom)
-    {
+                                                final KnownProblem knownProblemFillFrom) {
         TestPlanDto testPlanToFill = new TestPlanDto();
         if (null == meta || null == meta.name() || meta.name().length() == 0) {
             testPlanToFill.setName(desc.getClassName());
@@ -192,8 +189,7 @@ public class TestDtoHelper {
      * @return the test plan dto
      */
     public static TestPlanDto createTestPlanDto(final Class<?> testPlanClass, final TestPlan meta,
-                                                final KnownProblem knownProblemFillFrom)
-    {
+                                                final KnownProblem knownProblemFillFrom) {
         TestPlanDto testPlanToFill = new TestPlanDto();
         if (null == meta || null == meta.name() || meta.name().length() == 0) {
             testPlanToFill.setName(testPlanClass.getName());
@@ -217,8 +213,7 @@ public class TestDtoHelper {
      * @return the test case dto
      */
     public static TestCaseDto createTestCaseDto(final Description desc, final TestCase meta,
-                                                final KnownProblem knownProblemFillFrom, final TestPlan tpMeta)
-    {
+                                                final KnownProblem knownProblemFillFrom, final TestPlan tpMeta) {
         TestCaseDto testCaseToFill = new TestCaseDto();
         if (null == meta || null == meta.name() || meta.name().length() == 0) {
             testCaseToFill.setName(desc.getMethodName());
@@ -243,8 +238,7 @@ public class TestDtoHelper {
      * @return the test case dto
      */
     public static TestCaseDto createTestCaseDto(final String testPlanClass, final String testCaseMethod,
-                                                final TestCase meta, final KnownProblem knownProblemFillFrom, final TestPlan tpMeta)
-    {
+                                                final TestCase meta, final KnownProblem knownProblemFillFrom, final TestPlan tpMeta) {
         TestCaseDto testCaseToFill = new TestCaseDto();
         if (null == meta || null == meta.name() || meta.name().length() == 0) {
             testCaseToFill.setName(testCaseMethod);

--- a/testah-junit/src/main/java/org/testah/framework/report/AbstractFormatter.java
+++ b/testah-junit/src/main/java/org/testah/framework/report/AbstractFormatter.java
@@ -7,11 +7,7 @@ import org.apache.velocity.app.VelocityEngine;
 import org.testah.TS;
 import org.testah.framework.cli.Params;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.StringWriter;
+import java.io.*;
 import java.nio.charset.Charset;
 
 /**
@@ -111,7 +107,7 @@ public abstract class AbstractFormatter {
         }
         final int size = TS.getMaskValues().keySet().size();
         return StringUtils.replaceEach(report, TS.getMaskValues().keySet().toArray(new String[size]),
-            TS.getMaskValues().values().toArray(new String[size]));
+                TS.getMaskValues().values().toArray(new String[size]));
     }
 
     /**

--- a/testah-junit/src/main/java/org/testah/framework/report/HtmlFormatter.java
+++ b/testah-junit/src/main/java/org/testah/framework/report/HtmlFormatter.java
@@ -20,6 +20,7 @@ public class HtmlFormatter extends AbstractTestPlanFormatter {
 
     /**
      * Override getContext(...) in AbstractTestPlanFormatter
+     *
      * @see org.testah.framework.report.AbstractFormatter#getContext(org.apache.velocity.VelocityContext)
      */
     public VelocityContext getContext(final VelocityContext context) {

--- a/testah-junit/src/main/java/org/testah/framework/report/SummaryHtmlFormatter.java
+++ b/testah-junit/src/main/java/org/testah/framework/report/SummaryHtmlFormatter.java
@@ -24,6 +24,7 @@ public class SummaryHtmlFormatter extends AbstractSummaryFormatter {
 
     /**
      * Override getContext(...) in AbstractSummaryFormatter.
+     *
      * @see org.testah.framework.report.AbstractFormatter#getContext(org.apache.velocity.VelocityContext)
      */
     public VelocityContext getContext(final VelocityContext context) {
@@ -40,7 +41,7 @@ public class SummaryHtmlFormatter extends AbstractSummaryFormatter {
                 counts.put(TestStatus.IGNORE, counts.get(TestStatus.IGNORE) + result.getTestPlan().getRunInfo().getIgnore());
             } else {
                 int pass = result.getJunitResult().getRunCount()
-                    - (result.getJunitResult().getFailureCount() + result.getJunitResult().getIgnoreCount());
+                        - (result.getJunitResult().getFailureCount() + result.getJunitResult().getIgnoreCount());
                 counts.put(TestStatus.PASSED, counts.get(TestStatus.PASSED) + pass);
                 counts.put(TestStatus.FAILED, counts.get(TestStatus.FAILED) + result.getJunitResult().getFailureCount());
                 counts.put(TestStatus.IGNORE, counts.get(TestStatus.IGNORE) + result.getJunitResult().getIgnoreCount());
@@ -48,10 +49,9 @@ public class SummaryHtmlFormatter extends AbstractSummaryFormatter {
         });
 
         context.put("GoogleChart",
-            getGoogleChart(counts.get(TestStatus.FAILED), counts.get(TestStatus.PASSED), counts.get(TestStatus.IGNORE)));
+                getGoogleChart(counts.get(TestStatus.FAILED), counts.get(TestStatus.PASSED), counts.get(TestStatus.IGNORE)));
 
-        context.put("htmlPath","");
-
+        context.put("htmlPath", "");
 
 
         return context;
@@ -73,7 +73,7 @@ public class SummaryHtmlFormatter extends AbstractSummaryFormatter {
      */
     private String getGoogleChart(final int numFail, final int numPass, final int numIgnore) {
         return "http://chart.apis.google.com/chart?chs=400x100&chco=ff2233,00aa33,C0C0C0&chd=t:" + numFail + "," + numPass + "," + numIgnore
-            + "&cht=p3&chl=Failed [" + numFail + "]|Passed [" + numPass + "]|Ignore [" + numIgnore + "]&chtt=Run Results";
+                + "&cht=p3&chl=Failed [" + numFail + "]|Passed [" + numPass + "]|Ignore [" + numIgnore + "]&chtt=Run Results";
     }
 
 }

--- a/testah-junit/src/main/java/org/testah/framework/report/TestPlanReporter.java
+++ b/testah-junit/src/main/java/org/testah/framework/report/TestPlanReporter.java
@@ -1,8 +1,8 @@
 package org.testah.framework.report;
 
-import java.io.File;
-import java.util.HashMap;
-
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.testah.TS;
 import org.testah.client.dto.TestPlanDto;
 import org.testah.driver.http.requests.PostRequestDto;
@@ -14,9 +14,8 @@ import org.testah.framework.report.jira.JiraReporter;
 import org.testah.framework.testPlan.AbstractTestPlan;
 import org.testah.runner.testPlan.TestPlanActor;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.File;
+import java.util.HashMap;
 
 /**
  * The Class TestPlanReporter.
@@ -48,7 +47,7 @@ public class TestPlanReporter {
         if (null == testPlan) {
             TS.log().info(Cli.BAR_LONG);
             TS.log().info(
-                Cli.BAR_WALL + "No Tests Ran, could be due to use of filters, for details turn on trace logging");
+                    Cli.BAR_WALL + "No Tests Ran, could be due to use of filters, for details turn on trace logging");
 
             if (null != ignored) {
                 ignored.forEach((k, v) -> TS.log().info(Cli.BAR_WALL + "" + v + " - " + k));
@@ -59,20 +58,20 @@ public class TestPlanReporter {
         try {
             testPlan.getRunInfo().setIgnore(AbstractTestPlan.getIgnoredTests().size());
             testPlan.getRunInfo()
-                .setTotal(testPlan.getRunInfo().getFail() + testPlan.getRunInfo().getPass() + testPlan.getRunInfo().getIgnore());
+                    .setTotal(testPlan.getRunInfo().getFail() + testPlan.getRunInfo().getPass() + testPlan.getRunInfo().getIgnore());
             testPlan.getRunInfo().getRunTimeProperties().put("builtOn", TS.params().getComputerName());
         } catch (final Exception e) {
             TS.log().trace(e);
         }
 
-        if (TestPlanActor.isResultsInUse()) {
+        if (TestPlanActor.isResultsInUse() || TS.params().isUniqueReportName()) {
             filename += "_" + testPlan.getSource().replace(".", "_") + "_" + TS.util().nowUnique();
         }
         final org.testah.client.dto.RunInfoDto ri = testPlan.getRunInfo();
         System.out.println("\n\n\n");
         TS.log().info(Cli.BAR_LONG);
         TS.log().info(Cli.BAR_WALL + "TestPlan[" + testPlan.getSource() + " (thread:" + Thread.currentThread().getId() + ") Status: "
-            + testPlan.getStatusEnum());
+                + testPlan.getStatusEnum());
         TS.log().info(Cli.BAR_WALL + "Passed: " + ri.getPass());
         TS.log().info(Cli.BAR_WALL + "Failed: " + ri.getFail());
         TS.log().info(Cli.BAR_WALL + "Ignore/NA/FilteredOut: " + ri.getIgnore());
@@ -113,7 +112,7 @@ public class TestPlanReporter {
                 jiraReporter.createOrUpdateTestPlanRemoteLink(testPlan, this.getJiraRemoteLinkBuilder());
             } else {
                 TS.log().warn("Use Jira is On, but JiraRemoteLinkBuilder is not set, can set ex: "
-                    + "TS.getTestPlanReporter().setJiraRemoteLinkBuilder(jiraRemoteLinkBuilder);");
+                        + "TS.getTestPlanReporter().setJiraRemoteLinkBuilder(jiraRemoteLinkBuilder);");
             }
         }
         if (null == TS.params().getSendJsonTestDataToService() || TS.params().getSendJsonTestDataToService().length() > 0) {
@@ -122,19 +121,19 @@ public class TestPlanReporter {
                 map.configure(JsonGenerator.Feature.ESCAPE_NON_ASCII, true);
                 TS.log().info(Cli.BAR_WALL + "Posting Data: ");
                 final ResponseDto response = TS.http().doRequest(
-                    new PostRequestDto(TS.params().getSendJsonTestDataToService(), AbstractTestPlan.getTestPlan())
-                        .withJsonUTF8(),
-                    false).print(true);
+                        new PostRequestDto(TS.params().getSendJsonTestDataToService(), AbstractTestPlan.getTestPlan())
+                                .withJsonUTF8(),
+                        false).print(true);
                 TS.log().trace("Request Payload:\n" + response.getRequestUsed().getPayloadString());
                 TS.log().trace("Response Body:\n" + response.getResponseBody());
                 try {
                     final HashMap<String, String> values = TS.util().getMap().readValue(response.getResponseBody(),
-                        new TypeReference<HashMap<String, String>>() {
-                        });
+                            new TypeReference<HashMap<String, String>>() {
+                            });
                     if (null != values.get("message")) {
                         final HashMap<Integer, String> ids = TS.util().getMap().readValue(values.get("message"),
-                            new TypeReference<HashMap<Integer, String>>() {
-                            });
+                                new TypeReference<HashMap<Integer, String>>() {
+                                });
                         TS.log().info(Cli.BAR_LONG);
                         TS.log().info(Cli.BAR_WALL + "Ids From TMS");
                         ids.forEach((k, v) -> TS.log().info("ID[ " + k + " ] - " + v));
@@ -145,7 +144,7 @@ public class TestPlanReporter {
 
             } catch (final Exception e) {
                 TS.log().warn("Issue posting data to declared service: " + TS.params().getSendJsonTestDataToService(),
-                    e);
+                        e);
             }
         }
 

--- a/testah-junit/src/main/java/org/testah/framework/report/VerboseAsserts.java
+++ b/testah-junit/src/main/java/org/testah/framework/report/VerboseAsserts.java
@@ -1672,28 +1672,72 @@ public class VerboseAsserts {
         return isFalse(message + " - Is Empty", actual);
     }
 
-    public boolean isGreaterThan(String message, final Number valueToBeGreaterThan, final Number actual) {
-        return isGreaterThan(message, valueToBeGreaterThan, actual, false);
-    }
 
+    /**
+     * Is greater than or equal to boolean.
+     *
+     * @param message              the message
+     * @param valueToBeGreaterThan the value to be greater than
+     * @param actual               the actual
+     * @return the boolean
+     */
     public boolean isGreaterThanOrEqualTo(String message, final Number valueToBeGreaterThan, final Number actual) {
         return isGreaterThan(message, valueToBeGreaterThan, actual, true);
     }
 
-    public boolean isGreaterThan(String message, final Number valueToBeGreaterThan, final Number actual, final boolean allowEqualTo) {
-        return isGreaterThan(message, new BigDecimal(valueToBeGreaterThan.toString()), new BigDecimal(actual.toString()), allowEqualTo);
-    }
 
-    public boolean isGreaterThan(String message, final BigDecimal valueToBeGreaterThan, final BigDecimal actual) {
-        return isGreaterThan("", valueToBeGreaterThan, actual, false);
-    }
-
+    /**
+     * Is greater than or equal to boolean.
+     *
+     * @param message              the message
+     * @param valueToBeGreaterThan the value to be greater than
+     * @param actual               the actual
+     * @return the boolean
+     */
     public boolean isGreaterThanOrEqualTo(String message, final BigDecimal valueToBeGreaterThan, final BigDecimal actual) {
         return isGreaterThan("", valueToBeGreaterThan, actual, true);
 
     }
 
-    private boolean isGreaterThan(String message, final BigDecimal valueToBeGreaterThan, final BigDecimal actual, final boolean allowEqualTo) {
+    /**
+     * Is greater than boolean.
+     *
+     * @param message              the message
+     * @param valueToBeGreaterThan the value to be greater than
+     * @param actual               the actual
+     * @param allowEqualTo         the allow equal to
+     * @return the boolean
+     */
+    public boolean isGreaterThan(String message, final Number valueToBeGreaterThan, final Number actual, final boolean allowEqualTo) {
+        return isGreaterThan(message, new BigDecimal(valueToBeGreaterThan.toString()), new BigDecimal(actual.toString()), allowEqualTo);
+    }
+
+    /**
+     * Is greater than boolean.
+     *
+     * @param message              the message
+     * @param valueToBeGreaterThan the value to be greater than
+     * @param actual               the actual
+     * @return the boolean
+     */
+    public boolean isGreaterThan(String message, final Number valueToBeGreaterThan, final Number actual) {
+        return isGreaterThan(message, valueToBeGreaterThan, actual, false);
+    }
+
+    /**
+     * Is greater than boolean.
+     *
+     * @param message              the message
+     * @param valueToBeGreaterThan the value to be greater than
+     * @param actual               the actual
+     * @return the boolean
+     */
+    public boolean isGreaterThan(String message, final BigDecimal valueToBeGreaterThan, final BigDecimal actual) {
+        return isGreaterThan("", valueToBeGreaterThan, actual, false);
+    }
+
+    private boolean isGreaterThan(String message, final BigDecimal valueToBeGreaterThan, final BigDecimal actual,
+                                  final boolean allowEqualTo) {
         String assertMethod = (allowEqualTo ? "isGreaterThanOrEqualTo" : "isGreaterThan");
         try {
 
@@ -1716,26 +1760,79 @@ public class VerboseAsserts {
         }
     }
 
-    public boolean isLessThan(String message, final Number valueToBeLessThan, final Number actual) {
-        return isLessThan(message, valueToBeLessThan, actual, false);
-    }
-
+    /**
+     * Is less than or equal to boolean.
+     *
+     * @param message           the message
+     * @param valueToBeLessThan the value to be less than
+     * @param actual            the actual
+     * @return the boolean
+     */
     public boolean isLessThanOrEqualTo(String message, final Number valueToBeLessThan, final Number actual) {
         return isLessThan(message, valueToBeLessThan, actual, true);
     }
 
-    public boolean isLessThan(String message, final Number valueToBeLessThan, final Number actual, final boolean allowEqualTo) {
-        return isLessThan(message, new BigDecimal(valueToBeLessThan.toString()), new BigDecimal(actual.toString()), allowEqualTo);
-    }
 
-    public boolean isLessThan(String message, final BigDecimal valueToBeLessThan, final BigDecimal actual) {
-        return isLessThan(message, valueToBeLessThan, actual, false);
-    }
-
+    /**
+     * Is less than or equal to boolean.
+     *
+     * @param message           the message
+     * @param valueToBeLessThan the value to be less than
+     * @param actual            the actual
+     * @return the boolean
+     */
     public boolean isLessThanOrEqualTo(String message, final BigDecimal valueToBeLessThan, final BigDecimal actual) {
         return isLessThan(message, valueToBeLessThan, actual, true);
     }
 
+    /**
+     * Is less than boolean.
+     *
+     * @param message           the message
+     * @param valueToBeLessThan the value to be less than
+     * @param actual            the actual
+     * @return the boolean
+     */
+    public boolean isLessThan(String message, final Number valueToBeLessThan, final Number actual) {
+        return isLessThan(message, valueToBeLessThan, actual, false);
+    }
+
+
+    /**
+     * Is less than boolean.
+     *
+     * @param message           the message
+     * @param valueToBeLessThan the value to be less than
+     * @param actual            the actual
+     * @param allowEqualTo      the allow equal to
+     * @return the boolean
+     */
+    public boolean isLessThan(String message, final Number valueToBeLessThan, final Number actual, final boolean allowEqualTo) {
+        return isLessThan(message, new BigDecimal(valueToBeLessThan.toString()), new BigDecimal(actual.toString()), allowEqualTo);
+    }
+
+    /**
+     * Is less than boolean.
+     *
+     * @param message           the message
+     * @param valueToBeLessThan the value to be less than
+     * @param actual            the actual
+     * @return the boolean
+     */
+    public boolean isLessThan(String message, final BigDecimal valueToBeLessThan, final BigDecimal actual) {
+        return isLessThan(message, valueToBeLessThan, actual, false);
+    }
+
+
+    /**
+     * Is less than boolean.
+     *
+     * @param message           the message
+     * @param valueToBeLessThan the value to be less than
+     * @param actual            the actual
+     * @param allowEqualTo      the allow equal to
+     * @return the boolean
+     */
     public boolean isLessThan(String message, final BigDecimal valueToBeLessThan, final BigDecimal actual, final boolean allowEqualTo) {
         String assertMethod = (allowEqualTo ? "isLessThanOrEqualTo" : "isLessThan");
 
@@ -1764,7 +1861,6 @@ public class VerboseAsserts {
      *
      * @return true, if successful
      */
-
     public boolean pass() {
         return pass("");
     }

--- a/testah-junit/src/main/java/org/testah/framework/report/jira/AbstractJiraRemoteLinkBuilder.java
+++ b/testah-junit/src/main/java/org/testah/framework/report/jira/AbstractJiraRemoteLinkBuilder.java
@@ -4,12 +4,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.testah.TS;
 import org.testah.client.dto.TestCaseDto;
 import org.testah.client.dto.TestPlanDto;
-import org.testah.framework.report.jira.dto.Application;
-import org.testah.framework.report.jira.dto.Icon;
-import org.testah.framework.report.jira.dto.Icon2;
-import org.testah.framework.report.jira.dto.RemoteIssueLinkDto;
-import org.testah.framework.report.jira.dto.RemoteIssueLinkObject;
-import org.testah.framework.report.jira.dto.Status;
+import org.testah.framework.report.jira.dto.*;
 import org.testah.framework.testPlan.AbstractTestPlan;
 
 /**
@@ -268,13 +263,11 @@ public abstract class AbstractJiraRemoteLinkBuilder implements JiraRemoteLinkBui
 
     }
 
-    public String getFileExt()
-    {
+    public String getFileExt() {
         return fileExt;
     }
 
-    public void setFileExt(final String fileExt)
-    {
+    public void setFileExt(final String fileExt) {
         this.fileExt = fileExt;
     }
 

--- a/testah-junit/src/main/java/org/testah/framework/report/jira/JiraReporter.java
+++ b/testah-junit/src/main/java/org/testah/framework/report/jira/JiraReporter.java
@@ -15,8 +15,7 @@ import org.testah.framework.report.jira.dto.RemoteIssueLinkDto;
 import java.util.ArrayList;
 import java.util.List;
 
-public class JiraReporter
-{
+public class JiraReporter {
 
     private final String baseUrl;
     private static final String apiUrl = "rest/api/latest";
@@ -24,8 +23,7 @@ public class JiraReporter
     /**
      * Constructor.
      */
-    public JiraReporter()
-    {
+    public JiraReporter() {
         if (TS.params().getJiraUrl().endsWith("/")) {
             this.baseUrl = TS.params().getJiraUrl() + apiUrl;
         } else {
@@ -39,8 +37,7 @@ public class JiraReporter
      * @param testPlan          the test plan
      * @param remoteLinkBuilder JiraRemoteLinkBuilder
      */
-    public void createOrUpdateTestPlanRemoteLink(final TestPlanDto testPlan, final JiraRemoteLinkBuilder remoteLinkBuilder)
-    {
+    public void createOrUpdateTestPlanRemoteLink(final TestPlanDto testPlan, final JiraRemoteLinkBuilder remoteLinkBuilder) {
         if (TS.params().isUseJiraRemoteLink() && TS.params().getJiraUrl().length() > 0) {
             RemoteIssueLinkDto remoteLink;
             if (!testPlan.getRelatedIds().isEmpty()) {
@@ -90,7 +87,8 @@ public class JiraReporter
                                 if (null == remoteLink) {
                                     createRemoteLink(relatedId, remoteLinkBuilder.getRemoteLinkForTestCaseResult(testCase));
                                 } else {
-                                    updateRemoteLink(relatedId, remoteLink.getId(), remoteLinkBuilder.getRemoteLinkForTestCaseResult(testCase));
+                                    updateRemoteLink(relatedId, remoteLink.getId(),
+                                            remoteLinkBuilder.getRemoteLinkForTestCaseResult(testCase));
                                 }
                             }
                         }
@@ -100,8 +98,7 @@ public class JiraReporter
         }
     }
 
-    private <T> T addAuthHeader(final AbstractRequestDto<T> request)
-    {
+    private <T> T addAuthHeader(final AbstractRequestDto<T> request) {
         return request.addBasicAuth(TS.params().getJiraUserName(), TS.params().getJiraPassword());
     }
 
@@ -111,8 +108,7 @@ public class JiraReporter
      * @param issue the issue
      * @return list of remote issue link
      */
-    public List<RemoteIssueLinkDto> getRemoteLinks(final String issue)
-    {
+    public List<RemoteIssueLinkDto> getRemoteLinks(final String issue) {
         try {
             if (!StringUtils.isEmpty(issue)) {
                 GetRequestDto get = new GetRequestDto(baseUrl + "/issue/" + issue
@@ -135,8 +131,7 @@ public class JiraReporter
      * @param globalId global id
      * @return remote issue link for global id
      */
-    public RemoteIssueLinkDto getRemoteLinkForGlobalId(final String issue, final String globalId)
-    {
+    public RemoteIssueLinkDto getRemoteLinkForGlobalId(final String issue, final String globalId) {
         if (null != issue && null != globalId) {
             for (RemoteIssueLinkDto link : getRemoteLinks(issue)) {
                 if (link.getGlobalId().equals(globalId)) {
@@ -154,8 +149,7 @@ public class JiraReporter
      * @param remoteLink remote link to create
      * @return remote issue link
      */
-    public RemoteIssueLinkDto createRemoteLink(final String issue, final RemoteIssueLinkDto remoteLink)
-    {
+    public RemoteIssueLinkDto createRemoteLink(final String issue, final RemoteIssueLinkDto remoteLink) {
         try {
             if (!StringUtils.isEmpty(issue)) {
                 if (null != remoteLink) {
@@ -177,8 +171,7 @@ public class JiraReporter
      * @param remoteLink remote issue link
      * @return response of HTTP request
      */
-    public ResponseDto updateRemoteLink(final String issue, final int id, final RemoteIssueLinkDto remoteLink)
-    {
+    public ResponseDto updateRemoteLink(final String issue, final int id, final RemoteIssueLinkDto remoteLink) {
         try {
             if (!StringUtils.isEmpty(issue)) {
                 if (null != remoteLink) {

--- a/testah-junit/src/main/java/org/testah/framework/report/jira/dto/Application.java
+++ b/testah-junit/src/main/java/org/testah/framework/report/jira/dto/Application.java
@@ -1,11 +1,6 @@
 package org.testah.framework.report.jira.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.*;
 
 import javax.annotation.Generated;
 import java.util.HashMap;

--- a/testah-junit/src/main/java/org/testah/framework/report/jira/dto/Icon.java
+++ b/testah-junit/src/main/java/org/testah/framework/report/jira/dto/Icon.java
@@ -1,11 +1,6 @@
 package org.testah.framework.report.jira.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.*;
 
 import javax.annotation.Generated;
 import java.util.HashMap;

--- a/testah-junit/src/main/java/org/testah/framework/report/jira/dto/Icon2.java
+++ b/testah-junit/src/main/java/org/testah/framework/report/jira/dto/Icon2.java
@@ -1,11 +1,6 @@
 package org.testah.framework.report.jira.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.*;
 
 import javax.annotation.Generated;
 import java.util.HashMap;

--- a/testah-junit/src/main/java/org/testah/framework/report/jira/dto/RemoteIssueLinkDto.java
+++ b/testah-junit/src/main/java/org/testah/framework/report/jira/dto/RemoteIssueLinkDto.java
@@ -1,11 +1,6 @@
 package org.testah.framework.report.jira.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.*;
 
 import javax.annotation.Generated;
 import java.util.HashMap;

--- a/testah-junit/src/main/java/org/testah/framework/report/jira/dto/RemoteIssueLinkObject.java
+++ b/testah-junit/src/main/java/org/testah/framework/report/jira/dto/RemoteIssueLinkObject.java
@@ -1,11 +1,6 @@
 package org.testah.framework.report.jira.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.*;
 
 import javax.annotation.Generated;
 import java.util.HashMap;

--- a/testah-junit/src/main/java/org/testah/framework/report/jira/dto/Status.java
+++ b/testah-junit/src/main/java/org/testah/framework/report/jira/dto/Status.java
@@ -1,11 +1,6 @@
 package org.testah.framework.report.jira.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.*;
 
 import javax.annotation.Generated;
 import java.util.HashMap;

--- a/testah-junit/src/main/java/org/testah/framework/report/mgmt/AuditReport.java
+++ b/testah-junit/src/main/java/org/testah/framework/report/mgmt/AuditReport.java
@@ -1,14 +1,7 @@
 package org.testah.framework.report.mgmt;
 
 import org.apache.poi.hssf.util.HSSFColor;
-import org.apache.poi.ss.usermodel.BorderStyle;
-import org.apache.poi.ss.usermodel.Cell;
-import org.apache.poi.ss.usermodel.CellStyle;
-import org.apache.poi.ss.usermodel.FillPatternType;
-import org.apache.poi.ss.usermodel.HorizontalAlignment;
-import org.apache.poi.ss.usermodel.IndexedColors;
-import org.apache.poi.ss.usermodel.Row;
-import org.apache.poi.ss.usermodel.VerticalAlignment;
+import org.apache.poi.ss.usermodel.*;
 import org.apache.poi.xssf.usermodel.XSSFFont;
 import org.apache.poi.xssf.usermodel.XSSFSheet;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
@@ -39,6 +32,7 @@ public class AuditReport {
 
     /**
      * Constructor.
+     *
      * @throws IOException if writing to file fails
      */
     public AuditReport() throws IOException {
@@ -139,18 +133,18 @@ public class AuditReport {
         final HashMap<String, TestPlanDto> testPlans = new HashMap<>();
         for (final Class<?> test : testPlanFilter.getTestClassesMetFilters()) {
             testPlans
-                .put(test.getCanonicalName(),
-                    TestDtoHelper
-                        .createTestPlanDto(test, test.getAnnotation(TestPlan.class),
-                            test.getAnnotation(KnownProblem.class))
-                        .setRunTime(null).setRunInfo(null));
+                    .put(test.getCanonicalName(),
+                            TestDtoHelper
+                                    .createTestPlanDto(test, test.getAnnotation(TestPlan.class),
+                                            test.getAnnotation(KnownProblem.class))
+                                    .setRunTime(null).setRunInfo(null));
 
             for (final Method method : test.getDeclaredMethods()) {
                 if (null != method.getAnnotation(TestCase.class)) {
                     testPlans.get(test.getCanonicalName())
-                        .addTestCase(TestDtoHelper.createTestCaseDto(test.getCanonicalName(), method.getName(),
-                            method.getAnnotation(TestCase.class), method.getAnnotation(KnownProblem.class),
-                            test.getAnnotation(TestPlan.class)).setRunTime(null));
+                            .addTestCase(TestDtoHelper.createTestCaseDto(test.getCanonicalName(), method.getName(),
+                                    method.getAnnotation(TestCase.class), method.getAnnotation(KnownProblem.class),
+                                    test.getAnnotation(TestPlan.class)).setRunTime(null));
                 }
             }
         }
@@ -177,12 +171,12 @@ public class AuditReport {
         Row tpRow = testPlanSheet.createRow(tpRowNum++);
 
         addHeader(tcRow, "TestPlan", "TestCase", "RunTypes", "ACCEPTANCE", "SMOKE", "REG", "RunTypes", "TestType",
-            "HasKnownProblem", "Platforms",
-            "Components", "Comments", "Description", "KnownProblem Ids", "KnownProblem Desc", "KnownProblem Type");
+                "HasKnownProblem", "Platforms",
+                "Components", "Comments", "Description", "KnownProblem Ids", "KnownProblem Desc", "KnownProblem Type");
 
         addHeader(tpRow, "TestPlan", "Description", "RunTypes", "ACCEPTANCE", "SMOKE", "REG", "RunTypes", "TestType",
-            "HasKnownProblem", "Platforms",
-            "Components", "Comments", "KnownProblem Ids", "KnownProblem Desc", "KnownProblem Type");
+                "HasKnownProblem", "Platforms",
+                "Components", "Comments", "KnownProblem Ids", "KnownProblem Desc", "KnownProblem Type");
 
         for (final Entry<String, TestPlanDto> testPlan : testPlans.entrySet()) {
             tpRow = testPlanSheet.createRow(tpRowNum++);
@@ -202,16 +196,16 @@ public class AuditReport {
             if (null != testPlan.getValue().getKnownProblem()) {
                 if (null != testPlan.getValue().getKnownProblem().getLinkedIds()) {
                     addToCell(tcRow.createCell(tpColNum++), String.join(", ", testPlan.getValue()
-                        .getKnownProblem()
-                        .getLinkedIds()));
+                            .getKnownProblem()
+                            .getLinkedIds()));
                 } else {
                     addToCell(tcRow.createCell(tpColNum++), "");
                 }
                 addToCell(tcRow.createCell(tpColNum++), testPlan.getValue().getKnownProblem()
-                    .getDescription());
+                        .getDescription());
                 addToCell(tcRow.createCell(tpColNum++), testPlan.getValue().getKnownProblem()
-                    .getTypeOfKnown()
-                    .name());
+                        .getTypeOfKnown()
+                        .name());
             }
 
             for (final TestCaseDto testCase : testPlan.getValue().getTestCases()) {
@@ -233,13 +227,13 @@ public class AuditReport {
                 if (null != testCase.getKnownProblem()) {
                     if (null != testCase.getKnownProblem().getLinkedIds()) {
                         addToCell(tcRow.createCell(tcColNum++), String.join(", ", testCase.getKnownProblem()
-                            .getLinkedIds()));
+                                .getLinkedIds()));
                     } else {
                         addToCell(tcRow.createCell(tcColNum++), "");
                     }
                     addToCell(tcRow.createCell(tcColNum++), testCase.getKnownProblem().getDescription());
                     addToCell(tcRow.createCell(tcColNum++), testCase.getKnownProblem().getTypeOfKnown()
-                        .name());
+                            .name());
                 }
                 tcRow.setHeightInPoints(-1);
                 // cell.setCellValue((Integer) field);

--- a/testah-junit/src/main/java/org/testah/framework/report/performance/dto/ChunkStats.java
+++ b/testah-junit/src/main/java/org/testah/framework/report/performance/dto/ChunkStats.java
@@ -1,12 +1,12 @@
 package org.testah.framework.report.performance.dto;
 
+import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
+import org.testah.runner.http.load.HttpAkkaStats;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-
-import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
-import org.testah.runner.http.load.HttpAkkaStats;
 
 public class ChunkStats {
 
@@ -18,7 +18,7 @@ public class ChunkStats {
     /**
      * Constructor for holder of statistical data of the the execution of a chunk of requests.
      *
-     * @param stats    overall execution data for a chunk of requests
+     * @param stats overall execution data for a chunk of requests
      */
     public ChunkStats(HttpAkkaStats stats) {
         setElapsedTime(stats.getDuration());

--- a/testah-junit/src/main/java/org/testah/framework/report/performance/dto/RequestExecutionDuration.java
+++ b/testah-junit/src/main/java/org/testah/framework/report/performance/dto/RequestExecutionDuration.java
@@ -18,6 +18,7 @@ public class RequestExecutionDuration {
 
     /**
      * Constructor.
+     *
      * @param aggregation either 'chunk' or 'single'
      */
     public RequestExecutionDuration(String aggregation) {
@@ -26,6 +27,7 @@ public class RequestExecutionDuration {
 
     /**
      * Get the time stamp for the request.
+     *
      * @return the timestamp
      */
     public String getTimestamp() {
@@ -34,6 +36,7 @@ public class RequestExecutionDuration {
 
     /**
      * Set the time stamp for the request.
+     *
      * @param timestamp the timestamp to set
      * @return this object
      */
@@ -44,6 +47,7 @@ public class RequestExecutionDuration {
 
     /**
      * Get the collection time stamp. This can be used to group the response times for a chunk of requests.
+     *
      * @return the collection time
      */
     public String getCollectionTime() {
@@ -52,6 +56,7 @@ public class RequestExecutionDuration {
 
     /**
      * Set the collection time stamp. This is the time when the data for one chunk of requests was collected.
+     *
      * @param timestamp the collection time to set
      * @return this object
      */
@@ -62,6 +67,7 @@ public class RequestExecutionDuration {
 
     /**
      * Get the name of the service to which the requests are sent.
+     *
      * @return the service
      */
     public String getService() {
@@ -70,6 +76,7 @@ public class RequestExecutionDuration {
 
     /**
      * Set the name of the service to which the requests are sent.
+     *
      * @param service the service to set
      * @return this object
      */
@@ -80,6 +87,7 @@ public class RequestExecutionDuration {
 
     /**
      * Get the domain name of the service url to which the requests are sent.
+     *
      * @return the domain
      */
     public String getDomain() {
@@ -88,6 +96,7 @@ public class RequestExecutionDuration {
 
     /**
      * Set the domain name of the service url to which the requests are sent.
+     *
      * @param domain the domain to set
      * @return this object
      */
@@ -98,6 +107,7 @@ public class RequestExecutionDuration {
 
     /**
      * Get the name of the test class/plan.
+     *
      * @return the testClass
      */
     public String getTestClass() {
@@ -106,6 +116,7 @@ public class RequestExecutionDuration {
 
     /**
      * Set the name of the test class/plan.
+     *
      * @param testClass the testClass to set
      * @return this object
      */
@@ -116,6 +127,7 @@ public class RequestExecutionDuration {
 
     /**
      * Get the name of the test method/case.
+     *
      * @return the testMethod
      */
     public String getTestMethod() {
@@ -124,6 +136,7 @@ public class RequestExecutionDuration {
 
     /**
      * Set the name of the test method/case.
+     *
      * @param testMethod the testMethod to set
      * @return this object
      */
@@ -134,6 +147,7 @@ public class RequestExecutionDuration {
 
     /**
      * Get the request status code.
+     *
      * @return the statusCode
      */
     public Integer getStatusCode() {
@@ -142,6 +156,7 @@ public class RequestExecutionDuration {
 
     /**
      * Set the request status code.
+     *
      * @param statusCode the statusCode to set
      * @return this object
      */
@@ -152,6 +167,7 @@ public class RequestExecutionDuration {
 
     /**
      * Get the duration of the request.
+     *
      * @return the duration
      */
     public long getDuration() {
@@ -160,6 +176,7 @@ public class RequestExecutionDuration {
 
     /**
      * Set the duration of the request.
+     *
      * @param duration the duration to set
      * @return this object
      */
@@ -170,6 +187,7 @@ public class RequestExecutionDuration {
 
     /**
      * Get the aggregation.
+     *
      * @return the type
      */
     public String getAggregation() {

--- a/testah-junit/src/main/java/org/testah/framework/report/performance/dto/StatsDetails.java
+++ b/testah-junit/src/main/java/org/testah/framework/report/performance/dto/StatsDetails.java
@@ -1,10 +1,9 @@
 package org.testah.framework.report.performance.dto;
 
-import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
-import org.testah.runner.http.load.HttpAkkaStats;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
+import org.testah.runner.http.load.HttpAkkaStats;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class StatsDetails {
@@ -30,24 +29,26 @@ public class StatsDetails {
 
     /**
      * Constructor for holder of basic overall statistical execution of a chunk of requests.
+     *
      * @param stats overall execution data for a chunk of requests
      */
     public StatsDetails(HttpAkkaStats stats) {
         this.setMean(stats.getAvgDuration()).setCount((long) stats.getTotalResponses())
-            .setMax(stats.getLongestDuration()).setMin(stats.getShortestDuration())
-            .setPct90((long) stats.getStatsDuration().getPercentile(percentile90))
-            .setStd((long) stats.getStatsDuration().getStandardDeviation());
+                .setMax(stats.getLongestDuration()).setMin(stats.getShortestDuration())
+                .setPct90((long) stats.getStatsDuration().getPercentile(percentile90))
+                .setStd((long) stats.getStatsDuration().getStandardDeviation());
     }
 
     /**
      * Constructor for holder of basic overall statistical execution of a chunk of requests.
+     *
      * @param stats execution data for a chunk of requests related to a status code
      */
     public StatsDetails(DescriptiveStatistics stats) {
         this.setMean((long) stats.getMean()).setCount(stats.getN())
-            .setMax((long) stats.getMax()).setMin((long) stats.getMin())
-            .setPct90((long) stats.getPercentile(percentile90))
-            .setStd((long) stats.getStandardDeviation());
+                .setMax((long) stats.getMax()).setMin((long) stats.getMin())
+                .setPct90((long) stats.getPercentile(percentile90))
+                .setStd((long) stats.getStandardDeviation());
     }
 
     @JsonProperty("count")

--- a/testah-junit/src/main/java/org/testah/framework/testPlan/AbstractTestPlan.java
+++ b/testah-junit/src/main/java/org/testah/framework/testPlan/AbstractTestPlan.java
@@ -1,18 +1,8 @@
 package org.testah.framework.testPlan;
 
-import org.junit.AfterClass;
-import org.junit.Assume;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.Test.None;
-import org.junit.rules.ExternalResource;
-import org.junit.rules.RuleChain;
-import org.junit.rules.TestName;
-import org.junit.rules.TestRule;
-import org.junit.rules.TestWatcher;
-import org.junit.rules.Timeout;
+import org.junit.rules.*;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import org.slf4j.MDC;

--- a/testah-junit/src/main/java/org/testah/runner/HttpAkkaRunner.java
+++ b/testah-junit/src/main/java/org/testah/runner/HttpAkkaRunner.java
@@ -1,10 +1,6 @@
 package org.testah.runner;
 
-import akka.actor.ActorRef;
-import akka.actor.ActorSystem;
-import akka.actor.Props;
-import akka.actor.UntypedActor;
-import akka.actor.UntypedActorFactory;
+import akka.actor.*;
 import org.testah.TS;
 import org.testah.driver.http.AbstractHttpWrapper;
 import org.testah.driver.http.HttpWrapperV2;
@@ -54,18 +50,17 @@ public class HttpAkkaRunner {
      * @return the list
      */
     public List<ResponseDto> runAndReport(final int numConcurrent, final AbstractRequestDto<?> request,
-                                          final int numOfRequestsToMake)
-    {
+                                          final int numOfRequestsToMake) {
         final List<ResponseDto> responses = runTests(numConcurrent, request, numOfRequestsToMake);
         if (TS.http().isVerbose()) {
             int responseCount = 1;
             for (final ResponseDto response : responses) {
                 TS.log().info(String.format(rptInfo,
-                                responseCount++,
-                                response.getStatusCode(),
-                                response.getStatusText(),
-                                TS.util().toDateString(response.getStart()),
-                                TS.util().toDateString(response.getEnd())));
+                        responseCount++,
+                        response.getStatusCode(),
+                        response.getStatusText(),
+                        TS.util().toDateString(response.getStart()),
+                        TS.util().toDateString(response.getEnd())));
             }
         }
         TS.util().toJsonPrint(new HttpAkkaStats(responses));
@@ -82,18 +77,17 @@ public class HttpAkkaRunner {
      */
     public List<ResponseDto> runAndReport(final int numConcurrent,
                                           final ConcurrentLinkedQueue<?> concurrentLinkedQueue,
-                                          boolean isVerbose)
-    {
+                                          boolean isVerbose) {
         final List<ResponseDto> responses = runTests(numConcurrent, concurrentLinkedQueue, isVerbose);
         if (isVerbose) {
             int responseCount = 1;
             for (final ResponseDto response : responses) {
                 TS.log().info(String.format(rptInfo,
-                    responseCount++,
-                    response.getStatusCode(),
-                    response.getStatusText(),
-                    TS.util().toDateString(response.getStart()),
-                    TS.util().toDateString(response.getEnd())));
+                        responseCount++,
+                        response.getStatusCode(),
+                        response.getStatusText(),
+                        TS.util().toDateString(response.getStart()),
+                        TS.util().toDateString(response.getEnd())));
             }
         }
         return responses;
@@ -108,8 +102,7 @@ public class HttpAkkaRunner {
      * @return the list
      */
     public List<ResponseDto> runTests(final int numConcurrent, final AbstractRequestDto<?> request,
-                                      final int numOfRequestsToMake)
-    {
+                                      final int numOfRequestsToMake) {
         final Long hashId = Thread.currentThread().getId();
         try {
             if (null == request) {

--- a/testah-junit/src/main/java/org/testah/runner/TestahJUnitRunner.java
+++ b/testah-junit/src/main/java/org/testah/runner/TestahJUnitRunner.java
@@ -1,18 +1,14 @@
 package org.testah.runner;
 
-import akka.actor.ActorRef;
-import akka.actor.ActorSystem;
-import akka.actor.Props;
-import akka.actor.UntypedActor;
-import akka.actor.UntypedActorFactory;
+import akka.actor.*;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.testah.TS;
 import org.testah.framework.dto.ResultDto;
 import org.testah.framework.testPlan.AbstractTestPlan;
 import org.testah.runner.testPlan.TestPlanActor;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 /**
  * The Class TestahJUnitRunner.
@@ -21,6 +17,10 @@ public class TestahJUnitRunner {
 
     private static boolean inUse = false;
 
+    public List<ResultDto> runTests(final int numConcurrent, final List<Class<?>> junitTestPlanClasses) {
+        return runTests(numConcurrent, junitTestPlanClasses, true);
+    }
+
     /**
      * Run tests.
      *
@@ -28,10 +28,14 @@ public class TestahJUnitRunner {
      * @param junitTestPlanClasses the junit test plan classes
      * @return the list
      */
-    public List<ResultDto> runTests(final int numConcurrent, final List<Class<?>> junitTestPlanClasses) {
+    public List<ResultDto> runTests(final int numConcurrent, final List<Class<?>> junitTestPlanClasses, final boolean onlyUniqueTests) {
         setInUse(true);
         if (null != junitTestPlanClasses) {
-            return runTests(numConcurrent, new HashSet<Class<?>>(junitTestPlanClasses));
+            if (onlyUniqueTests) {
+                return runTestsInternal(numConcurrent, Lists.newArrayList(Sets.newHashSet(junitTestPlanClasses)));
+            } else {
+                return runTestsInternal(numConcurrent, junitTestPlanClasses);
+            }
         }
         setInUse(false);
         return null;
@@ -44,7 +48,7 @@ public class TestahJUnitRunner {
      * @param junitTestPlanClasses the junit test plan classes
      * @return the list
      */
-    private List<ResultDto> runTests(final int numConcurrent, final Set<Class<?>> junitTestPlanClasses) {
+    private List<ResultDto> runTestsInternal(final int numConcurrent, final List<Class<?>> junitTestPlanClasses) {
         try {
             if (null == junitTestPlanClasses || junitTestPlanClasses.size() == 0) {
                 TS.log().warn("No TestPlans Found to Run!");

--- a/testah-junit/src/main/java/org/testah/runner/http/load/HttpActor.java
+++ b/testah-junit/src/main/java/org/testah/runner/http/load/HttpActor.java
@@ -24,9 +24,10 @@ public class HttpActor extends UntypedActor {
 
     /**
      * Constructor.
-     * @param nrOfWorkers number of Akka workers
+     *
+     * @param nrOfWorkers   number of Akka workers
      * @param numOfAttempts number of attempts
-     * @param hashId Akka actor hash
+     * @param hashId        Akka actor hash
      */
     public HttpActor(final int nrOfWorkers, final int numOfAttempts, final Long hashId) {
         this.hashId = hashId;
@@ -34,11 +35,12 @@ public class HttpActor extends UntypedActor {
         this.nrOfWorkers = nrOfWorkers;
         this.numOfAttempts = numOfAttempts;
         workerRouter = this.getContext()
-            .actorOf(new Props(HttpWorker.class).withRouter(new RoundRobinRouter(nrOfWorkers)), "workerRouter");
+                .actorOf(new Props(HttpWorker.class).withRouter(new RoundRobinRouter(nrOfWorkers)), "workerRouter");
     }
 
     /**
      * Implementation of UntypedActor.onReceiver(...).
+     *
      * @see akka.actor.UntypedActor#onReceive(java.lang.Object)
      */
     @SuppressWarnings("unchecked")
@@ -85,6 +87,7 @@ public class HttpActor extends UntypedActor {
 
     /**
      * Get the responses for a particular Akka actor.
+     *
      * @param hashId of Akka actor
      * @return list of responses
      */
@@ -98,6 +101,7 @@ public class HttpActor extends UntypedActor {
 
     /**
      * Get responses per Akka actor hash.
+     *
      * @return map of hash id to list of responses.
      */
     public static HashMap<Long, List<ResponseDto>> getResults() {

--- a/testah-junit/src/main/java/org/testah/runner/http/load/HttpAkkaStats.java
+++ b/testah-junit/src/main/java/org/testah/runner/http/load/HttpAkkaStats.java
@@ -1,14 +1,13 @@
 package org.testah.runner.http.load;
 
+import com.google.common.primitives.Doubles;
+import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
+import org.testah.driver.http.response.ResponseDto;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
-import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
-import org.testah.driver.http.response.ResponseDto;
-
-import com.google.common.primitives.Doubles;
 
 public class HttpAkkaStats {
 
@@ -22,6 +21,7 @@ public class HttpAkkaStats {
 
     /**
      * Constructor. Takes the provided responses to generate execution statistics.
+     *
      * @param responses list of service responses
      */
     public HttpAkkaStats(final List<ResponseDto> responses) {
@@ -55,6 +55,7 @@ public class HttpAkkaStats {
 
     /**
      * Get the number of responses grouped by HTTP status code.
+     *
      * @return map of number of responses per status code
      */
     public Map<Integer, Integer> getStatusCodes() {
@@ -67,6 +68,7 @@ public class HttpAkkaStats {
 
     /**
      * Get the number of registered responses.
+     *
      * @return number of all responses
      */
     public int getTotalResponses() {
@@ -75,6 +77,7 @@ public class HttpAkkaStats {
 
     /**
      * Get the time stamp in milliseconds of the first response.
+     *
      * @return the start timestamp
      */
     public Long getStartTime() {
@@ -83,6 +86,7 @@ public class HttpAkkaStats {
 
     /**
      * Get the time stamp in milliseconds of the last response.
+     *
      * @return the last response time stamp
      */
     public Long getEndTime() {
@@ -91,6 +95,7 @@ public class HttpAkkaStats {
 
     /**
      * Get the elapsed time in milliseconds for the requests.
+     *
      * @return the elapsed time
      */
     public Long getDuration() {
@@ -99,6 +104,7 @@ public class HttpAkkaStats {
 
     /**
      * Get the average duration of a request.
+     *
      * @return the mean duration in milliseconds
      */
     public Long getAvgDuration() {
@@ -107,6 +113,7 @@ public class HttpAkkaStats {
 
     /**
      * Get the shortest duration of a request.
+     *
      * @return the shortest duration of a request
      */
     public Long getShortestDuration() {
@@ -115,6 +122,7 @@ public class HttpAkkaStats {
 
     /**
      * Get the longest duration of a request.
+     *
      * @return the longest duration of a request
      */
     public Long getLongestDuration() {
@@ -123,6 +131,7 @@ public class HttpAkkaStats {
 
     /**
      * Get the list of durations of all the requests in the completed order.
+     *
      * @return the list of all durations
      */
     public List<Long> getDurations() {
@@ -131,6 +140,7 @@ public class HttpAkkaStats {
 
     /**
      * Return the org.apache.commons.math3.stat.descriptive.DescriptiveStatistics object build from all durations for additional statistical data.
+     *
      * @return DescriptiveStatistics object build from all durations
      */
     public DescriptiveStatistics getStatsDuration() {
@@ -139,6 +149,7 @@ public class HttpAkkaStats {
 
     /**
      * Return the org.apache.commons.math3.stat.descriptive.DescriptiveStatistics object build for each HTTP code for additional statistical data.
+     *
      * @return map DescriptiveStatistics of durations for each HTTP status code
      */
     public Map<Integer, DescriptiveStatistics> getStatsDurationPerStatus() {

--- a/testah-junit/src/main/java/org/testah/runner/http/load/HttpWorker.java
+++ b/testah-junit/src/main/java/org/testah/runner/http/load/HttpWorker.java
@@ -1,17 +1,17 @@
 package org.testah.runner.http.load;
 
-import java.util.concurrent.ConcurrentLinkedQueue;
-
+import akka.actor.UntypedActor;
 import org.testah.driver.http.AbstractHttpWrapper;
 import org.testah.driver.http.requests.AbstractRequestDto;
 import org.testah.runner.HttpAkkaRunner;
 
-import akka.actor.UntypedActor;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 public class HttpWorker extends UntypedActor {
 
     /**
      * Wrapper of UntypedActor.onReceive(...).
+     *
      * @see akka.actor.UntypedActor#onReceive(java.lang.Object)
      */
     public void onReceive(final Object arg0) throws Exception {

--- a/testah-junit/src/main/java/org/testah/runner/performance/AbstractLoadTest.java
+++ b/testah-junit/src/main/java/org/testah/runner/performance/AbstractLoadTest.java
@@ -1,17 +1,17 @@
 package org.testah.runner.performance;
 
-import java.io.InputStreamReader;
-import java.nio.charset.Charset;
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.ConcurrentLinkedQueue;
-
 import org.joda.time.DateTime;
 import org.testah.TS;
 import org.testah.driver.http.requests.AbstractRequestDto;
 import org.testah.driver.http.response.ResponseDto;
 import org.testah.runner.HttpAkkaRunner;
 import org.testah.runner.performance.dto.LoadTestSequenceDto;
+
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 public abstract class AbstractLoadTest {
     private static final String RUN_LOG_MESSAGE = "Executing step %d of %d with : threads=%d, chunksize=%d, duration=%d minutes";
@@ -20,9 +20,8 @@ public abstract class AbstractLoadTest {
     private TestRunProperties runProps;
     private List<ExecutionStatsPublisher> publishers;
 
-    protected void initialize(TestDataGenerator loadTestDataGenerator, TestRunProperties runProps, ExecutionStatsPublisher... publishers) 
-            throws Exception
-    {
+    protected void initialize(TestDataGenerator loadTestDataGenerator, TestRunProperties runProps, ExecutionStatsPublisher... publishers)
+            throws Exception {
         this.loadTestDataGenerator = loadTestDataGenerator;
         this.runProps = runProps;
         this.runProps.setDomain(loadTestDataGenerator.getDomain());
@@ -32,7 +31,7 @@ public abstract class AbstractLoadTest {
     protected void runTest(String resourceFile) throws Exception {
         LoadTestSequenceDto[] loadTestSequence =
                 TS.util().getMap().readValue(new InputStreamReader(this.getClass().getClassLoader().getResourceAsStream(resourceFile),
-                        Charset.forName("UTF-8")),
+                                Charset.forName("UTF-8")),
                         LoadTestSequenceDto[].class);
         Arrays.stream(loadTestSequence).forEach(step -> {
             TS.log().info(String.format(RUN_LOG_MESSAGE,
@@ -54,10 +53,11 @@ public abstract class AbstractLoadTest {
     }
 
     /**
-     * Execute the HTTP requests, gather and publish the statistics. A concrete test may have multiple 
+     * Execute the HTTP requests, gather and publish the statistics. A concrete test may have multiple
      * calls to ramp up, steady level and ramp down.
-     * @param numThreads number of Akka threads
-     * @param chunkSize number of bundled requests
+     *
+     * @param numThreads          number of Akka threads
+     * @param chunkSize           number of bundled requests
      * @param timeIntervalMinutes time to run requests
      * @throws Exception when HTTP request generation fails
      */
@@ -69,7 +69,7 @@ public abstract class AbstractLoadTest {
 
         while (System.currentTimeMillis() < runProps.getStopTime()) {
             List<ConcurrentLinkedQueue<AbstractRequestDto<?>>> concurrentLinkedQueues =
-                loadTestDataGenerator.generateRequests();
+                    loadTestDataGenerator.generateRequests();
             for (ConcurrentLinkedQueue<AbstractRequestDto<?>> concurrentLinkedQueue : concurrentLinkedQueues) {
                 try {
                     responses = akkaRunner.runAndReport(runProps.getNumberOfAkkaThreads(), concurrentLinkedQueue, runProps.isVerbose());

--- a/testah-junit/src/main/java/org/testah/runner/performance/AbstractLongRunningTest.java
+++ b/testah-junit/src/main/java/org/testah/runner/performance/AbstractLongRunningTest.java
@@ -1,12 +1,12 @@
 package org.testah.runner.performance;
 
-import java.util.List;
-import java.util.concurrent.ConcurrentLinkedQueue;
-
 import org.testah.TS;
 import org.testah.driver.http.requests.AbstractRequestDto;
 import org.testah.driver.http.response.ResponseDto;
 import org.testah.runner.HttpAkkaRunner;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 public abstract class AbstractLongRunningTest {
 
@@ -14,12 +14,12 @@ public abstract class AbstractLongRunningTest {
      * Execute the HTTP requests, gather and publish the statistics.
      *
      * @param loadTestDataGenerator the class that generates the requests
-     * @param runProps properties that describe the test execution
-     * @param publishers 0 or more ExecutionStatsPublisher, e.g. to push the statistics to Elasticsearch
+     * @param runProps              properties that describe the test execution
+     * @param publishers            0 or more ExecutionStatsPublisher, e.g. to push the statistics to Elasticsearch
      * @throws Exception when HTTP request generation fails
      */
     public void executeTest(TestDataGenerator loadTestDataGenerator, TestRunProperties runProps,
-            ExecutionStatsPublisher... publishers) throws Exception {
+                            ExecutionStatsPublisher... publishers) throws Exception {
         List<ResponseDto> responses;
         runProps.setDomain(loadTestDataGenerator.getDomain());
 

--- a/testah-junit/src/main/java/org/testah/runner/performance/AbstractPerformanceRestRequest.java
+++ b/testah-junit/src/main/java/org/testah/runner/performance/AbstractPerformanceRestRequest.java
@@ -1,10 +1,10 @@
 package org.testah.runner.performance;
 
-import java.util.Arrays;
-import java.util.List;
-
 import org.testah.driver.http.requests.AbstractRequestDto;
 import org.testah.util.TupleGenerator;
+
+import java.util.Arrays;
+import java.util.List;
 
 public abstract class AbstractPerformanceRestRequest {
     public AbstractPerformanceRestRequest(List<?>... lists) {
@@ -17,6 +17,7 @@ public abstract class AbstractPerformanceRestRequest {
 
     /**
      * Get the number of distinct tuples.
+     *
      * @return count of distinct tuples
      */
     public int countDistinct() {

--- a/testah-junit/src/main/java/org/testah/runner/performance/ChunkStatsLogPublisher.java
+++ b/testah-junit/src/main/java/org/testah/runner/performance/ChunkStatsLogPublisher.java
@@ -1,13 +1,12 @@
 package org.testah.runner.performance;
 
-import java.util.List;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.testah.TS;
 import org.testah.driver.http.response.ResponseDto;
 import org.testah.framework.report.performance.dto.ChunkStats;
 import org.testah.runner.http.load.HttpAkkaStats;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
 
 public class ChunkStatsLogPublisher implements ExecutionStatsPublisher {
 
@@ -26,8 +25,7 @@ public class ChunkStatsLogPublisher implements ExecutionStatsPublisher {
     }
 
     @Override
-    public void cleanup()
-    {
+    public void cleanup() {
         // no post processing required
     }
 }

--- a/testah-junit/src/main/java/org/testah/runner/performance/ElasticSearchResponseTimesPublisher.java
+++ b/testah-junit/src/main/java/org/testah/runner/performance/ElasticSearchResponseTimesPublisher.java
@@ -49,8 +49,7 @@ public class ElasticSearchResponseTimesPublisher implements ExecutionStatsPublis
                                                String type,
                                                String username,
                                                String password,
-                                               TestRunProperties runProps)
-    {
+                                               TestRunProperties runProps) {
         this.password = password;
         this.index = index;
         this.baseUrl = baseUrl;
@@ -80,35 +79,35 @@ public class ElasticSearchResponseTimesPublisher implements ExecutionStatsPublis
                 setStartTime(response.getStart());
                 setEndTime(response.getEnd());
                 payloadBuilder
-                    .append(bulkCreateString)
-                    .append(String.format("%s%n", mapper.writeValueAsString(
-                        new RequestExecutionDuration(TYPE_SINGLE_REQUEST)
-                            .setCollectionTime(collectionTime)
-                            .setDomain(runProps.getDomain())
-                            .setDuration(response.getDuration())
-                            .setService(runProps.getServiceUnderTest())
-                            .setTestClass(runProps.getTestClass())
-                            .setTestMethod(runProps.getTestMethod())
-                            // Always use server time (GMT)
-                            .setTimestamp(getDateTimeString(response.getStart(), zoneId))
-                            .setStatusCode(response.getStatusCode())
-                    )));
+                        .append(bulkCreateString)
+                        .append(String.format("%s%n", mapper.writeValueAsString(
+                                new RequestExecutionDuration(TYPE_SINGLE_REQUEST)
+                                        .setCollectionTime(collectionTime)
+                                        .setDomain(runProps.getDomain())
+                                        .setDuration(response.getDuration())
+                                        .setService(runProps.getServiceUnderTest())
+                                        .setTestClass(runProps.getTestClass())
+                                        .setTestMethod(runProps.getTestMethod())
+                                        // Always use server time (GMT)
+                                        .setTimestamp(getDateTimeString(response.getStart(), zoneId))
+                                        .setStatusCode(response.getStatusCode())
+                        )));
             } catch (JsonProcessingException e) {
                 TS.log().info(e);
             }
         });
 
         payloadBuilder
-            .append(bulkCreateString)
-            .append(String.format("%s%n", mapper.writeValueAsString(
-                new RequestExecutionDuration(TYPE_CHUNK_OF_REQUESTS)
-                    .setTimestamp(collectionTime)
-                    .setDomain(runProps.getDomain())
-                    .setDuration(endTime - startTime)
-                    .setService(runProps.getServiceUnderTest())
-                    .setTestClass(runProps.getTestClass())
-                    .setTestMethod(runProps.getTestMethod()))
-            ));
+                .append(bulkCreateString)
+                .append(String.format("%s%n", mapper.writeValueAsString(
+                        new RequestExecutionDuration(TYPE_CHUNK_OF_REQUESTS)
+                                .setTimestamp(collectionTime)
+                                .setDomain(runProps.getDomain())
+                                .setDuration(endTime - startTime)
+                                .setService(runProps.getServiceUnderTest())
+                                .setTestClass(runProps.getTestClass())
+                                .setTestMethod(runProps.getTestMethod()))
+                ));
 
         PostRequestDto postRequestDto = new PostRequestDto(getUploadUrl(), payloadBuilder.toString());
         postRequestDto.setBasicAuthCredentials(username, password).withJson();
@@ -215,7 +214,7 @@ public class ElasticSearchResponseTimesPublisher implements ExecutionStatsPublis
     public static String getDateTimeString(LocalDateTime dateTime, ZoneOffset zoneOffset) {
         if (zoneOffset != null) {
             return ZonedDateTime.of(dateTime,
-                ZoneId.systemDefault()).withZoneSameInstant(zoneOffset).toLocalDateTime().format(dateTimeFormatter);
+                    ZoneId.systemDefault()).withZoneSameInstant(zoneOffset).toLocalDateTime().format(dateTimeFormatter);
         } else {
             return dateTime.format(dateTimeFormatter);
         }
@@ -233,8 +232,7 @@ public class ElasticSearchResponseTimesPublisher implements ExecutionStatsPublis
     }
 
     @Override
-    public void cleanup()
-    {
+    public void cleanup() {
         // no post processing required
     }
 }

--- a/testah-junit/src/main/java/org/testah/runner/performance/ExecutionStatsPublisher.java
+++ b/testah-junit/src/main/java/org/testah/runner/performance/ExecutionStatsPublisher.java
@@ -1,8 +1,8 @@
 package org.testah.runner.performance;
 
-import java.util.List;
-
 import org.testah.driver.http.response.ResponseDto;
+
+import java.util.List;
 
 public interface ExecutionStatsPublisher {
 

--- a/testah-junit/src/main/java/org/testah/runner/performance/TestDataGenerator.java
+++ b/testah-junit/src/main/java/org/testah/runner/performance/TestDataGenerator.java
@@ -22,13 +22,13 @@ public abstract class TestDataGenerator {
 
     /**
      * Add a request to the request list.
+     *
      * @param request http request
      * @return true if more requests need to be added to reach the requested number of requests
      */
     public boolean addRequest(AbstractRequestDto<?> request) {
         boolean keepGoing = false;
-        if (requestList.size() < totalRequests)
-        {
+        if (requestList.size() < totalRequests) {
             keepGoing = true;
             requestList.add(request);
         }
@@ -49,6 +49,7 @@ public abstract class TestDataGenerator {
 
     /**
      * Set the list of requests.
+     *
      * @param requestList the requestList to set
      */
     protected void setRequestList(List<AbstractRequestDto<?>> requestList) {

--- a/testah-junit/src/main/java/org/testah/runner/performance/TestRunProperties.java
+++ b/testah-junit/src/main/java/org/testah/runner/performance/TestRunProperties.java
@@ -1,13 +1,13 @@
 package org.testah.runner.performance;
 
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.testah.TS;
+
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
-import org.testah.TS;
 
 public class TestRunProperties {
     protected final Integer defaultNumberOfChunks = 2500;
@@ -45,12 +45,11 @@ public class TestRunProperties {
      * @param millisBetweenChunks time to pause between chunks
      */
     public TestRunProperties(
-        String serviceUnderTest,
-        String testClass,
-        String testMethod,
-        int numberOfAkkaThreads,
-        long millisBetweenChunks)
-    {
+            String serviceUnderTest,
+            String testClass,
+            String testMethod,
+            int numberOfAkkaThreads,
+            long millisBetweenChunks) {
         this.serviceUnderTest = serviceUnderTest;
         this.testClass = testClass;
         this.testMethod = testMethod;
@@ -308,6 +307,7 @@ public class TestRunProperties {
 
     /**
      * Set the domain for the service under test in the test run properties.
+     *
      * @param domain service domain
      * @return this object
      */

--- a/testah-junit/src/main/java/org/testah/runner/performance/dto/LoadTestSequenceDto.java
+++ b/testah-junit/src/main/java/org/testah/runner/performance/dto/LoadTestSequenceDto.java
@@ -5,11 +5,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder( {
-    LoadTestSequenceDto.PARAM_STEP,
-    LoadTestSequenceDto.PARAM_THREADS,
-    LoadTestSequenceDto.PARAM_CHUNK_SIZE,
-    LoadTestSequenceDto.PARAM_DURATION_MINUTES
+@JsonPropertyOrder({
+        LoadTestSequenceDto.PARAM_STEP,
+        LoadTestSequenceDto.PARAM_THREADS,
+        LoadTestSequenceDto.PARAM_CHUNK_SIZE,
+        LoadTestSequenceDto.PARAM_DURATION_MINUTES
 })
 public class LoadTestSequenceDto {
 

--- a/testah-junit/src/main/java/org/testah/runner/testPlan/TestPlanActor.java
+++ b/testah-junit/src/main/java/org/testah/runner/testPlan/TestPlanActor.java
@@ -18,6 +18,7 @@ public class TestPlanActor extends UntypedActor {
 
     /**
      * Constructor.
+     *
      * @param nrOfWorkers number of workders
      */
     public TestPlanActor(final int nrOfWorkers) {
@@ -28,6 +29,7 @@ public class TestPlanActor extends UntypedActor {
 
     /**
      * Override onReceive in UntypedActor.
+     *
      * @see akka.actor.UntypedActor#onReceive(java.lang.Object)
      */
     @SuppressWarnings("unchecked")
@@ -39,6 +41,10 @@ public class TestPlanActor extends UntypedActor {
             for (final Class<?> test : (Set<Class<?>>) message) {
                 workerRouter.tell(test, getSelf());
             }
+        } else if (message instanceof List) {
+            for (final Class<?> test : (List<Class<?>>) message) {
+                workerRouter.tell(test, getSelf());
+            }
         } else {
             for (int start = 0; start < nrOfWorkers; start++) {
                 workerRouter.tell(message, getSelf());
@@ -48,6 +54,7 @@ public class TestPlanActor extends UntypedActor {
 
     /**
      * Get the worker router.
+     *
      * @return the worker router
      */
     public ActorRef getWorkerRouter() {
@@ -56,6 +63,7 @@ public class TestPlanActor extends UntypedActor {
 
     /**
      * Get the results.
+     *
      * @return list of results
      */
     public static List<ResultDto> getResults() {
@@ -67,6 +75,7 @@ public class TestPlanActor extends UntypedActor {
 
     /**
      * Check it results is null.
+     *
      * @return return true if not null
      */
     public static boolean isResultsInUse() {

--- a/testah-junit/src/main/java/org/testah/runner/testPlan/TestPlanWorker.java
+++ b/testah-junit/src/main/java/org/testah/runner/testPlan/TestPlanWorker.java
@@ -9,6 +9,7 @@ public class TestPlanWorker extends UntypedActor {
 
     /**
      * Override the onReceive method in Untyped Actor.
+     *
      * @see akka.actor.UntypedActor#onReceive(java.lang.Object)
      */
     public void onReceive(final Object arg0) throws Exception {

--- a/testah-junit/src/main/java/org/testah/util/BashUtil.java
+++ b/testah-junit/src/main/java/org/testah/util/BashUtil.java
@@ -3,12 +3,7 @@ package org.testah.util;
 import org.apache.maven.wagon.util.IoUtils;
 import org.testah.TS;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.io.PrintWriter;
-import java.io.Writer;
+import java.io.*;
 
 /**
  * The Class BashUtil.

--- a/testah-junit/src/main/java/org/testah/util/ListUtil.java
+++ b/testah-junit/src/main/java/org/testah/util/ListUtil.java
@@ -12,7 +12,7 @@ public class ListUtil {
      *
      * @param list        the original list from which to compute the sublists
      * @param subListSize the size of the sublists
-     * @param <T> type of list elements
+     * @param <T>         type of list elements
      * @return list of sublists
      * @throws Exception when trying to create sublists that contain more elements than the original list
      */
@@ -36,7 +36,7 @@ public class ListUtil {
      * @param listOfSubLists list of sublists
      * @param sublist        the current sublist, initially empty.
      * @param subListSize    the size of the sublists
-     * @param <T> type of list elements
+     * @param <T>            type of list elements
      * @return list of sublists
      */
     private static <T> void getSublists(List<T> list, List<T> sublist, int subListSize, List<List<T>> listOfSubLists) {
@@ -62,7 +62,7 @@ public class ListUtil {
      * generated sublists is Sum(k=1..n) n!/((n-k)!*k!).
      *
      * @param list the original list
-     * @param <T> type of list elements
+     * @param <T>  type of list elements
      * @return the list of all sublists
      */
     public static <T> List<List<T>> getAllSublists(List<T> list) {

--- a/testah-junit/src/main/java/org/testah/util/SshUtil.java
+++ b/testah-junit/src/main/java/org/testah/util/SshUtil.java
@@ -1,20 +1,11 @@
 package org.testah.util;
 
-import com.jcraft.jsch.Channel;
-import com.jcraft.jsch.ChannelExec;
-import com.jcraft.jsch.ChannelShell;
-import com.jcraft.jsch.JSch;
-import com.jcraft.jsch.JSchException;
-import com.jcraft.jsch.Session;
+import com.jcraft.jsch.*;
 import org.testah.TS;
 import org.testah.framework.dto.StepAction;
 import org.testah.util.dto.ShellInfoDto;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.PrintStream;
+import java.io.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -122,8 +113,7 @@ public class SshUtil {
      * @throws JSchException the j sch exception
      */
     public Session getSession(final String username, final String host, final int port, final String password)
-        throws JSchException
-    {
+            throws JSchException {
         final Session session = jsch.getSession(username, host, port);
         session.setServerAliveInterval(120 * 1000);
         session.setServerAliveCountMax(1000);
@@ -141,8 +131,7 @@ public class SshUtil {
     }
 
     public String runShell(final Session session, final String... commands)
-        throws JSchException, IOException, InterruptedException
-    {
+            throws JSchException, IOException, InterruptedException {
         return runShellRtnInfo(session, commands).getOutput().toString();
 
     }
@@ -158,8 +147,7 @@ public class SshUtil {
      * @throws InterruptedException the interrupted exception
      */
     public ShellInfoDto runShellRtnInfo(final Session session, final String... commands)
-        throws JSchException, IOException, InterruptedException
-    {
+            throws JSchException, IOException, InterruptedException {
         ShellInfoDto info = new ShellInfoDto();
         this.lastExitCode = LAST_EXIT_CODE_DEFAULT;
         if (!session.isConnected()) {
@@ -252,8 +240,7 @@ public class SshUtil {
      * @throws InterruptedException the interrupted exception
      */
     public HashMap<Integer, List<String>> runShellEnhanced(final Session session, final String... commands)
-        throws JSchException, IOException, InterruptedException
-    {
+            throws JSchException, IOException, InterruptedException {
         final HashMap<Integer, List<String>> outputHash = new HashMap<>();
         final List<String> commandList = new ArrayList<>();
         int ctr = 0;
@@ -291,8 +278,7 @@ public class SshUtil {
      * @return the output lines for command
      */
     public List<String> getOutputLinesForCommand(final String command,
-                                                 final HashMap<Integer, List<String>> outputHash)
-    {
+                                                 final HashMap<Integer, List<String>> outputHash) {
         final List<String> lst = new ArrayList<>();
         if (null != command && null != outputHash && !outputHash.isEmpty()) {
             outputHash.forEach((key, value) -> {

--- a/testah-junit/src/main/java/org/testah/util/TestahUtil.java
+++ b/testah-junit/src/main/java/org/testah/util/TestahUtil.java
@@ -11,11 +11,7 @@ import org.joda.time.format.PeriodFormat;
 import org.testah.TS;
 import org.testah.framework.cli.Params;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.text.SimpleDateFormat;
@@ -280,7 +276,7 @@ public class TestahUtil {
     /**
      * Download file.
      *
-     * @param urlToUse the url to use
+     * @param urlToUse       the url to use
      * @param destinationDir the target directory
      * @return the file
      */

--- a/testah-junit/src/main/java/org/testah/util/TupleGenerator.java
+++ b/testah-junit/src/main/java/org/testah/util/TupleGenerator.java
@@ -19,7 +19,7 @@ public class TupleGenerator {
 
     /**
      * Constructor.
-     * 
+     *
      * @param listSizes size of each list
      */
     public TupleGenerator(int... listSizes) {
@@ -42,7 +42,7 @@ public class TupleGenerator {
      * </pre>
      * etc. Eventually, <code>next()</code> start over again with
      * <code>0,0,0</code>.
-     * 
+     *
      * @return the next combination of indices.
      */
     public List<Integer> nextTuple() {
@@ -54,7 +54,7 @@ public class TupleGenerator {
 
     /**
      * Get the number of unique combinations (the product of all list sizes).
-     * 
+     *
      * @return the number of distinct combinations
      */
     public int countDistinct() {

--- a/testah-junit/src/main/java/org/testah/util/database/AbstractDatabaseUtil.java
+++ b/testah-junit/src/main/java/org/testah/util/database/AbstractDatabaseUtil.java
@@ -13,15 +13,15 @@ public abstract class AbstractDatabaseUtil {
 
     /**
      * Constructor.
+     *
      * @param databaseName name of database
-     * @param host database host name
-     * @param port database port
-     * @param dbUser database user name
-     * @param dbPassword database password
+     * @param host         database host name
+     * @param port         database port
+     * @param dbUser       database user name
+     * @param dbPassword   database password
      */
     public AbstractDatabaseUtil(final String databaseName, final String host, final int port, final String dbUser,
-                                final String dbPassword)
-    {
+                                final String dbPassword) {
         this.databaseName = databaseName;
         this.host = host;
         this.port = port;

--- a/testah-junit/src/main/java/org/testah/util/database/PostgresDatabase.java
+++ b/testah-junit/src/main/java/org/testah/util/database/PostgresDatabase.java
@@ -3,13 +3,7 @@ package org.testah.util.database;
 import org.testah.TS;
 import org.testah.util.database.dto.SqlExecutionDto;
 
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
-import java.sql.SQLException;
-import java.sql.Statement;
+import java.sql.*;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -18,20 +12,21 @@ public class PostgresDatabase extends AbstractDatabaseUtil {
 
     /**
      * Constructor.
+     *
      * @param databaseName name of database
-     * @param host host name
-     * @param port database part
-     * @param dbUser db user name
-     * @param dbPassword db password
+     * @param host         host name
+     * @param port         database part
+     * @param dbUser       db user name
+     * @param dbPassword   db password
      */
     public PostgresDatabase(final String databaseName, final String host, final int port, final String dbUser,
-                            final String dbPassword)
-    {
+                            final String dbPassword) {
         super(databaseName, host, port, dbUser, dbPassword);
     }
 
     /**
-     *  Get the database connection.
+     * Get the database connection.
+     *
      * @see org.testah.util.database.AbstractDatabaseUtil#getConnection()
      */
     public Connection getConnection() throws SQLException {
@@ -42,6 +37,7 @@ public class PostgresDatabase extends AbstractDatabaseUtil {
 
     /**
      * Check if driver is loaded.
+     *
      * @see org.testah.util.database.AbstractDatabaseUtil#isDriverLoaded()
      */
     public boolean isDriverLoaded() throws Exception {
@@ -58,6 +54,7 @@ public class PostgresDatabase extends AbstractDatabaseUtil {
 
     /**
      * Execute SQL query.
+     *
      * @param sql the SQL query string
      * @return the SQL response as a map
      * @throws SQLException query execution fails
@@ -70,14 +67,14 @@ public class PostgresDatabase extends AbstractDatabaseUtil {
 
     /**
      * Execute SQL query.
-     * @param sql the SQL query string
+     *
+     * @param sql  the SQL query string
      * @param conn database connection
      * @return the SQL response as a map
      * @throws SQLException query execution fails
      */
     public List<HashMap<String, Object>> execuateSelectSql(final String sql, final Connection conn)
-        throws SQLException
-    {
+            throws SQLException {
         if (null == sql || !sql.toLowerCase().startsWith("select")) {
             throw new RuntimeException("execuateSelectSql can only use Select sql statement!");
         }
@@ -103,6 +100,7 @@ public class PostgresDatabase extends AbstractDatabaseUtil {
 
     /**
      * Execute SQL query.
+     *
      * @param sql the SQL query string
      * @return the SQL response
      * @throws SQLException query execution fails
@@ -115,7 +113,8 @@ public class PostgresDatabase extends AbstractDatabaseUtil {
 
     /**
      * Execute SQL query.
-     * @param sql the SQL query string
+     *
+     * @param sql  the SQL query string
      * @param conn database connection
      * @return the SQL response
      * @throws SQLException query execution fails

--- a/testah-junit/src/main/java/org/testah/util/database/dto/SqlExecutionDto.java
+++ b/testah-junit/src/main/java/org/testah/util/database/dto/SqlExecutionDto.java
@@ -16,6 +16,7 @@ public class SqlExecutionDto {
 
     /**
      * Constructor.
+     *
      * @param sql SQL string
      */
     public SqlExecutionDto(final String sql) {
@@ -24,6 +25,7 @@ public class SqlExecutionDto {
 
     /**
      * Mark the start of the SQL execution.
+     *
      * @return this object
      */
     public SqlExecutionDto start() {
@@ -33,6 +35,7 @@ public class SqlExecutionDto {
 
     /**
      * Mark the end to the SQL execution.
+     *
      * @return this object
      */
     public SqlExecutionDto end() {
@@ -44,6 +47,7 @@ public class SqlExecutionDto {
 
     /**
      * Get the start date/time.
+     *
      * @return the start date/time
      */
     public Date getStartTime() {
@@ -52,6 +56,7 @@ public class SqlExecutionDto {
 
     /**
      * Set the start date/time.
+     *
      * @param startTime the start date/time
      * @return this object
      */
@@ -62,6 +67,7 @@ public class SqlExecutionDto {
 
     /**
      * Get the end date/time.
+     *
      * @return the end date.
      */
     public Date getEndTime() {
@@ -70,6 +76,7 @@ public class SqlExecutionDto {
 
     /**
      * Set the end time.
+     *
      * @param endTime the end date
      * @return this object
      */
@@ -80,6 +87,7 @@ public class SqlExecutionDto {
 
     /**
      * Get the duration.
+     *
      * @return the duration
      */
     public Long getDuration() {
@@ -88,6 +96,7 @@ public class SqlExecutionDto {
 
     /**
      * Set the duration.
+     *
      * @param duration the duration
      * @return this object
      */
@@ -98,6 +107,7 @@ public class SqlExecutionDto {
 
     /**
      * Get the duration in readable format.
+     *
      * @return the duration
      */
     public String getDurationPretty() {
@@ -106,6 +116,7 @@ public class SqlExecutionDto {
 
     /**
      * Set the duration.
+     *
      * @param durationPretty the duration
      * @return this object
      */
@@ -116,6 +127,7 @@ public class SqlExecutionDto {
 
     /**
      * Get the SQL string.
+     *
      * @return the SQL string
      */
     public String getSql() {
@@ -124,6 +136,7 @@ public class SqlExecutionDto {
 
     /**
      * Get the result count.
+     *
      * @return the result count
      */
     public Integer getResultCount() {
@@ -132,6 +145,7 @@ public class SqlExecutionDto {
 
     /**
      * Set the result count.
+     *
      * @param resultCount the result count
      * @return this object
      */
@@ -142,6 +156,7 @@ public class SqlExecutionDto {
 
     /**
      * Get the update count.
+     *
      * @return update count
      */
     public Integer getUpdateCount() {
@@ -150,6 +165,7 @@ public class SqlExecutionDto {
 
     /**
      * Set the update count.
+     *
      * @param updateCount the count
      * @return this object
      */


### PR DESCRIPTION
- Added a new prop: param_uniqueReportName
     can be true for using unique names for reports, like when using test runner, is false by default
- Added ability to run a list of non unique tests, allowing for running for example 1 test many times concurrently.  By default is false, which is how it is now, using a hashset to de-dup the list passed in.
- Fixed checkstyle and formatting