### PR TITLE
add audit for require related ids

### DIFF
--- a/testah-junit/build.gradle
+++ b/testah-junit/build.gradle
@@ -13,7 +13,7 @@ apply plugin: 'idea'
 sourceCompatibility = 1.8
 group = 'org.testah'
 
-version = '1.1.6'
+version = '1.1.7'
 
 buildscript {
     repositories {

--- a/testah-junit/src/main/java/org/testah/framework/cli/Cli.java
+++ b/testah-junit/src/main/java/org/testah/framework/cli/Cli.java
@@ -6,6 +6,7 @@ import net.sourceforge.argparse4j.inf.*;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.testah.TS;
+import org.testah.client.dto.TestCaseDto;
 import org.testah.client.dto.TestPlanDto;
 import org.testah.client.enums.BrowserType;
 import org.testah.framework.annotations.KnownProblem;
@@ -51,7 +52,7 @@ public class Cli {
     /**
      * The Constant version.
      */
-    public static final String version = "1.1.5";
+    public static final String version = "1.1.7";
 
     /**
      * The Constant BAR_LONG.
@@ -129,6 +130,7 @@ public class Cli {
         query.addArgument("--file").required(false).action(Arguments.store()).dest("queryResults")
                 .setDefault(Params.getUserDir());
         query.addArgument("--includeMeta").required(false).action(Arguments.storeTrue()).dest("includeMeta");
+        query.addArgument("--requireRelatedIds").required(false).action(Arguments.storeTrue()).dest("requireRelatedIds");
         query.addArgument("--show").required(false).action(Arguments.storeTrue()).dest("showInConsole");
         query.addArgument("-i", "--lookAtInternalTests").setDefault(opt.getLookAtInternalTests()).type(String.class)
                 .help("lookAtInternalTests, example org.testah, will look at all tests under this package");
@@ -338,6 +340,28 @@ public class Cli {
                     }
                 }
             }
+
+            if (res.getBoolean("requireRelatedIds")) {
+                HashMap<TestPlanDto, List<TestCaseDto>> missingRelatedIds = new HashMap<>();
+                testPlans.values().parallelStream().forEach(testPlan -> {
+                    List<TestCaseDto> testCaseDtos = new ArrayList<>();
+                    testPlan.getTestCases().parallelStream().forEach(testCaseDto -> {
+                        if (testCaseDto.getRelatedIds() == null || testCaseDto.getRelatedIds().isEmpty()) {
+                            testCaseDtos.add(testCaseDto);
+                        }
+                    });
+                    if (!testCaseDtos.isEmpty()) {
+                        missingRelatedIds.put(testPlan, testCaseDtos);
+                    }
+                });
+                if (!missingRelatedIds.isEmpty()) {
+                    throw new RuntimeException("Metadata audit failure: At least 1 testcase is missing required " +
+                            "related field value! The value can be applied at the testplan level for all " +
+                            "testcases to get - " + TS.util().toJson(missingRelatedIds));
+                }
+            }
+
+
             resultObject = testPlans;
         }
 

--- a/testah-junit/src/main/java/org/testah/framework/cli/TestFilter.java
+++ b/testah-junit/src/main/java/org/testah/framework/cli/TestFilter.java
@@ -449,7 +449,7 @@ public class TestFilter {
                     final ClassLoader parent = this.getClass().getClassLoader();
 
                     public Object run() {
-                        return new GroovyClassLoader(parent);
+                            return new GroovyClassLoader(parent);
                     }
                 })) {
 

--- a/testah-junit/src/main/java/org/testah/framework/report/mgmt/AuditReport.java
+++ b/testah-junit/src/main/java/org/testah/framework/report/mgmt/AuditReport.java
@@ -19,7 +19,9 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map.Entry;
 
 public class AuditReport {
@@ -170,15 +172,21 @@ public class AuditReport {
         Row tcRow = testCaseSheet.createRow(tcRowNum++);
         Row tpRow = testPlanSheet.createRow(tpRowNum++);
 
-        addHeader(tcRow, "TestPlan", "TestCase", "RunTypes", "ACCEPTANCE", "SMOKE", "REG", "RunTypes", "TestType",
+        addHeader(tcRow, "TestPlan", "TestCase", "RunTypes", "ACCEPTANCE", "SMOKE", "REG", "RelatedIds", "TestType",
                 "HasKnownProblem", "Platforms",
                 "Components", "Comments", "Description", "KnownProblem Ids", "KnownProblem Desc", "KnownProblem Type");
 
-        addHeader(tpRow, "TestPlan", "Description", "RunTypes", "ACCEPTANCE", "SMOKE", "REG", "RunTypes", "TestType",
+        addHeader(tpRow, "TestPlan", "Description", "RunTypes", "ACCEPTANCE", "SMOKE", "REG", "RelatedIds", "TestType",
                 "HasKnownProblem", "Platforms",
                 "Components", "Comments", "KnownProblem Ids", "KnownProblem Desc", "KnownProblem Type");
 
+
+
         for (final Entry<String, TestPlanDto> testPlan : testPlans.entrySet()) {
+            List<String> tpRelatedIds = testPlan.getValue().getRelatedIds();
+            if(tpRelatedIds==null) {
+                tpRelatedIds = new ArrayList<>();
+            }
             tpRow = testPlanSheet.createRow(tpRowNum++);
             tpColNum = 0;
             addToCell(tpRow.createCell(tpColNum++), testPlan.getKey());
@@ -187,7 +195,7 @@ public class AuditReport {
             addToXCell(tpRow.createCell(tpColNum++), testPlan.getValue().getRunTypes().contains("ACCEPTANCE"));
             addToXCell(tpRow.createCell(tpColNum++), testPlan.getValue().getRunTypes().contains("SMOKE"));
             addToXCell(tpRow.createCell(tpColNum++), testPlan.getValue().getRunTypes().contains("REG"));
-            addToCell(tpRow.createCell(tpColNum++), String.join(", ", testPlan.getValue().getRunTypes()));
+            addToCell(tpRow.createCell(tpColNum++), String.join(", ", tpRelatedIds));
             addToCell(tpRow.createCell(tpColNum++), testPlan.getValue().getTestType().name());
             addToXCell(tpRow.createCell(tpColNum++), (null != testPlan.getValue().getKnownProblem()));
             addToCell(tpRow.createCell(tpColNum++), String.join(", ", testPlan.getValue().getPlatforms()));
@@ -209,6 +217,10 @@ public class AuditReport {
             }
 
             for (final TestCaseDto testCase : testPlan.getValue().getTestCases()) {
+                List<String> tcRelatedIds = testCase.getRelatedIds();
+                if(tcRelatedIds==null) {
+                    tcRelatedIds = tpRelatedIds;
+                }
                 tcRow = testCaseSheet.createRow(tcRowNum++);
                 tcColNum = 0;
                 addToCell(tcRow.createCell(tcColNum++), testPlan.getKey());
@@ -217,7 +229,7 @@ public class AuditReport {
                 addToXCell(tcRow.createCell(tcColNum++), testCase.getRunTypes().contains("ACCEPTANCE"));
                 addToXCell(tcRow.createCell(tcColNum++), testCase.getRunTypes().contains("SMOKE"));
                 addToXCell(tcRow.createCell(tcColNum++), testCase.getRunTypes().contains("REG"));
-                addToCell(tcRow.createCell(tcColNum++), String.join(", ", testCase.getRunTypes()));
+                addToCell(tcRow.createCell(tcColNum++), String.join(", ", tcRelatedIds));
                 addToCell(tcRow.createCell(tcColNum++), testCase.getTestType().name());
                 addToXCell(tcRow.createCell(tcColNum++), (null != testCase.getKnownProblem()));
                 addToCell(tcRow.createCell(tcColNum++), String.join(", ", testCase.getPlatforms()));

--- a/testah-junit/src/test/java/org/testah/framework/cli/CliTest.java
+++ b/testah-junit/src/test/java/org/testah/framework/cli/CliTest.java
@@ -70,6 +70,28 @@ public class CliTest {
         Assert.assertThat(cli.getTestPlanFilter().getTestClasses().size(), greaterThanOrEqualTo(50));
     }
 
+    @Test()
+    public void testCliQueryWithExternalAndRequireRelatedIdsFound() {
+        System.setProperty(PARAM_LOOK_AT_INTERNAL_TESTS, "org.testah.framework.cli.requirerelatedids");
+        System.setProperty("param_lookAtExternalTests", "test.groovy");
+        final String[] args = {"query", "--includeMeta", "--requireRelatedIds"};
+        final Cli cli = new Cli();
+        cli.getArgumentParser(args);
+        Assert.assertThat(cli.getTestPlanFilter().getTestClassesMetFilters().size(), greaterThanOrEqualTo(1));
+        Assert.assertThat(cli.getTestPlanFilter().getTestClasses().size(), greaterThanOrEqualTo(1));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testCliQueryWithExternalAndRequireRelatedIdsNotFound() {
+        System.setProperty(PARAM_LOOK_AT_INTERNAL_TESTS, ORG_TESTAH);
+        System.setProperty("param_lookAtExternalTests", "test.groovy");
+        final String[] args = {"query", "--includeMeta", "--requireRelatedIds"};
+        final Cli cli = new Cli();
+        cli.getArgumentParser(args);
+        Assert.assertThat(cli.getTestPlanFilter().getTestClassesMetFilters().size(), greaterThanOrEqualTo(46));
+        Assert.assertThat(cli.getTestPlanFilter().getTestClasses().size(), greaterThanOrEqualTo(50));
+    }
+
     @Test
     public void testCliCreate() {
         final String[] args = {"create"};

--- a/testah-junit/src/test/java/org/testah/framework/cli/requirerelatedids/TestRequiredRelatedIds.java
+++ b/testah-junit/src/test/java/org/testah/framework/cli/requirerelatedids/TestRequiredRelatedIds.java
@@ -1,0 +1,30 @@
+package org.testah.framework.cli.requirerelatedids;
+
+import org.junit.Test;
+import org.testah.client.enums.TestType;
+import org.testah.framework.annotations.TestCase;
+import org.testah.framework.annotations.TestPlan;
+import org.testah.framework.testPlan.HttpTestPlan;
+
+@TestPlan(relatedIds = {"test-123"})
+public class TestRequiredRelatedIds extends HttpTestPlan {
+
+    @TestCase
+    @Test
+    public void testFilterTestCaseTestType() {
+
+    }
+
+    @TestCase(testType = TestType.PENDING)
+    @Test
+    public void testShouldGetFilteredOut() {
+
+    }
+
+    @TestCase(relatedIds = {"test-123a"})
+    @Test
+    public void testFilterTestPlanTestType() {
+
+    }
+
+}


### PR DESCRIPTION
Add ability to run quick query audit to confirm all testcases have a related id associated with them.
Add related ids to the excel spreadsheet report.