### PR TITLE
fix issues with assertThat Method

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,12 +60,12 @@ jobs:
       - run: cd testah-junit && ./gradlew build
 
       - store_artifacts:
-        path: /home/circleci/repo/testah-junit/testah.log
+          path: /home/circleci/repo/testah-junit/testah.log
       - store_artifacts:
-        path: /home/circleci/repo/testah-junit/build/test-results/**/*
+          path: /home/circleci/repo/testah-junit/build/test-results/**/*
       - store_artifacts:
-        path: /home/circleci/repo/testah-junit/build/reports/tests/**/*
+          path: /home/circleci/repo/testah-junit/build/reports/tests/**/*
       # Save artifacts
       - store_test_results:
-        path: /home/circleci/repo/testah-junit/build/test-results
+          path: /home/circleci/repo/testah-junit/build/test-results
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,11 +59,11 @@ jobs:
       
       - run: cd testah-junit && ./gradlew build
 
-      - type: store_artifacts
+      - store_artifacts:
         path: /home/circleci/repo/testah-junit/testah.log
         path: /home/circleci/repo/testah-junit/build/test-results/**/*
         path: /home/circleci/repo/testah-junit/build/reports/tests/**/*
       # Save artifacts
-      - type: store_test_results
+      - store_test_results:
         path: /home/circleci/repo/testah-junit/build/test-results
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,9 @@ jobs:
 
       - store_artifacts:
         path: /home/circleci/repo/testah-junit/testah.log
+      - store_artifacts:
         path: /home/circleci/repo/testah-junit/build/test-results/**/*
+      - store_artifacts:
         path: /home/circleci/repo/testah-junit/build/reports/tests/**/*
       # Save artifacts
       - store_test_results:

--- a/README.md
+++ b/README.md
@@ -25,3 +25,4 @@ To build Testah projects, execute the following command within the testah-junit 
 cd testah-junit
 ./gradlew clean build
 ```
+

--- a/testah-junit/README.md
+++ b/testah-junit/README.md
@@ -25,7 +25,7 @@ repositories {
 
 dependencies {
     compile localGroovy()
-    compile 'org.testah:testah-junit:2.2.0'
+    compile 'org.testah:testah-junit:2.2.6'
 }
 ```
 

--- a/testah-junit/gradle.properties
+++ b/testah-junit/gradle.properties
@@ -1,3 +1,3 @@
 group=org.testah
-version=2.2.5
+version=2.2.6
 junitPlatformVersion=5.2.0

--- a/testah-junit/src/main/java/org/testah/framework/cli/Cli.java
+++ b/testah-junit/src/main/java/org/testah/framework/cli/Cli.java
@@ -38,7 +38,7 @@ public class Cli {
      * The Constant version.
      */
 
-    public static final String version = "2.2.5";
+    public static final String version = "2.2.6";
 
     /**
      * The Constant BAR_LONG.

--- a/testah-junit/src/main/java/org/testah/framework/report/VerboseAsserts.java
+++ b/testah-junit/src/main/java/org/testah/framework/report/VerboseAsserts.java
@@ -22,54 +22,50 @@ import java.util.*;
 /**
  * The Class VerboseAsserts.
  */
-public class VerboseAsserts
-{
-
+public class VerboseAsserts {
+    
     /**
      * The record steps.
      */
     private boolean recordSteps = true;
-
+    
     /**
      * The throw exception on fail.
      */
     private boolean throwExceptionOnFail;
-
+    
     /**
      * The is verify only.
      */
     private boolean isVerifyOnly = false;
-
+    
     /**
      * Instantiates a new verbose asserts.
      */
-    public VerboseAsserts()
-    {
+    public VerboseAsserts() {
         setRecordSteps(TS.params().isRecordSteps());
         throwExceptionOnFail = TS.params().isThrowExceptionOnFail();
     }
-
+    
     /**
      * Instantiates a new verbose asserts.
      *
      * @param throwExceptionOnFail the throw exception on fail
      */
-    public VerboseAsserts(final boolean throwExceptionOnFail)
-    {
+    public VerboseAsserts(final boolean throwExceptionOnFail) {
         this.throwExceptionOnFail = throwExceptionOnFail;
     }
-
+    
     /**
      * Custom assert boolean.
      *
      * @param runnableAssertBlock the runnable assert block
      * @return the boolean
      */
-    public boolean customAssert(final Runnable runnableAssertBlock)
-    {
+    public boolean customAssert(final Runnable runnableAssertBlock) {
         return customAssert("Custom Assert Block", runnableAssertBlock);
     }
-
+    
     /**
      * Custom assert boolean.
      *
@@ -77,23 +73,19 @@ public class VerboseAsserts
      * @param runnableAssertBlock the runnable assert block
      * @return the boolean
      */
-    public boolean customAssert(final String message, final Runnable runnableAssertBlock)
-    {
-        try
-        {
+    public boolean customAssert(final String message, final Runnable runnableAssertBlock) {
+        try {
             runnableAssertBlock.run();
             return addAssertHistory(message, true, "customAssert", true, true);
-        } catch (final Throwable e)
-        {
+        } catch (final Throwable e) {
             final boolean rtn = addAssertHistory(message, false, "customAssert", true, false, e);
-            if (getThrowExceptionOnFail())
-            {
+            if (getThrowExceptionOnFail()) {
                 throw e;
             }
             return rtn;
         }
     }
-
+    
     /**
      * Size equals.
      *
@@ -102,12 +94,11 @@ public class VerboseAsserts
      * @param expectedSize                the expected size
      * @return true, if successful
      */
-    public boolean sizeEquals(final String message, final Object objectToCheckSizeOrLengthOf, final int expectedSize)
-    {
+    public boolean sizeEquals(final String message, final Object objectToCheckSizeOrLengthOf, final int expectedSize) {
         return this.equalsTo(message + " - expected Object[" + objectToCheckSizeOrLengthOf +
-                "] to have a size/length of " + expectedSize, getSize(objectToCheckSizeOrLengthOf), expectedSize);
+            "] to have a size/length of " + expectedSize, getSize(objectToCheckSizeOrLengthOf), expectedSize);
     }
-
+    
     /**
      * Not size equals.
      *
@@ -117,48 +108,39 @@ public class VerboseAsserts
      * @return true, if successful
      */
     public boolean notSizeEquals(final String message, final Object objectToCheckSizeOrLengthOf,
-                                 final int expectedSize)
-    {
+                                 final int expectedSize) {
         return this.notEquals(message + " - expected Object[" + objectToCheckSizeOrLengthOf +
-                "] to have a size/length of " + expectedSize, getSize(objectToCheckSizeOrLengthOf), expectedSize);
+            "] to have a size/length of " + expectedSize, getSize(objectToCheckSizeOrLengthOf), expectedSize);
     }
-
+    
     /**
      * Gets the size.
      *
      * @param objectToCheck the object to check
      * @return the size
      */
-    private int getSize(final Object objectToCheck)
-    {
-        if (!notNull("Check the getSize objectToCheck is not null", objectToCheck))
-        {
+    private int getSize(final Object objectToCheck) {
+        if (!notNull("Check the getSize objectToCheck is not null", objectToCheck)) {
             return -1;
         }
         Integer actual = null;
-        if (objectToCheck instanceof String)
-        {
+        if (objectToCheck instanceof String) {
             actual = ((String) objectToCheck).length();
-        } else if (objectToCheck instanceof Object[])
-        {
+        } else if (objectToCheck instanceof Object[]) {
             actual = ((Object[]) objectToCheck).length;
-        } else if (objectToCheck instanceof Collection)
-        {
+        } else if (objectToCheck instanceof Collection) {
             actual = ((Collection<?>) objectToCheck).size();
-        } else if (objectToCheck instanceof AbstractMap)
-        {
+        } else if (objectToCheck instanceof AbstractMap) {
             actual = ((AbstractMap<?, ?>) objectToCheck).size();
         }
-        if (null != actual)
-        {
+        if (null != actual) {
             return actual;
-        } else
-        {
+        } else {
             throw new RuntimeException("Issue with object to Check for notEmpty Assert, object must be String, " +
-                    "ArrayList, Set, List or HashMap");
+                "ArrayList, Set, List or HashMap");
         }
     }
-
+    
     /**
      * Same json uses JSONAssert.
      *
@@ -166,11 +148,10 @@ public class VerboseAsserts
      * @param actual   the actual object will be converted to JSONObject
      * @return the boolean if true
      */
-    public boolean sameJson(final Object expected, final Object actual)
-    {
+    public boolean sameJson(final Object expected, final Object actual) {
         return sameJson("", expected, actual, true);
     }
-
+    
     /**
      * Same json uses JSONAssert.
      *
@@ -179,12 +160,11 @@ public class VerboseAsserts
      * @param actual   the actual
      * @return true, if successful
      */
-    public boolean sameJson(final String message, final Object expected, final Object actual)
-    {
+    public boolean sameJson(final String message, final Object expected, final Object actual) {
         return sameJson(message, expected, actual, true);
-
+        
     }
-
+    
     /**
      * Same json boolean.
      *
@@ -193,11 +173,10 @@ public class VerboseAsserts
      * @param strict   the strict
      * @return the boolean
      */
-    public boolean sameJson(final Object expected, final Object actual, final boolean strict)
-    {
+    public boolean sameJson(final Object expected, final Object actual, final boolean strict) {
         return sameJson("", expected, actual, strict);
     }
-
+    
     /**
      * Same json.
      *
@@ -207,8 +186,7 @@ public class VerboseAsserts
      * @param strict   the strict
      * @return true, if successful
      */
-    public boolean sameJson(final String message, final Object expected, final Object actual, final boolean strict)
-    {
+    public boolean sameJson(final String message, final Object expected, final Object actual, final boolean strict) {
         ObjectMapper mapper = new ObjectMapper();
         mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
         JSONObject expectedJsonNode = mapper.convertValue(expected, JSONObject.class);
@@ -217,7 +195,7 @@ public class VerboseAsserts
         //final JSONObject actualJsonNode = new JSONObject(actual);
         return sameJson(message, expectedJsonNode, actualJsonNode, strict);
     }
-
+    
     /**
      * Same json boolean.
      *
@@ -226,11 +204,10 @@ public class VerboseAsserts
      * @param strict   the strict
      * @return the boolean
      */
-    public boolean sameJson(final JSONObject expected, final JSONObject actual, final boolean strict)
-    {
+    public boolean sameJson(final JSONObject expected, final JSONObject actual, final boolean strict) {
         return sameJson("", expected, actual, strict);
     }
-
+    
     /**
      * Same json.
      *
@@ -240,23 +217,19 @@ public class VerboseAsserts
      * @param strict   the strict
      * @return true, if successful
      */
-    public boolean sameJson(final String message, final JSONObject expected, final JSONObject actual, final boolean strict)
-    {
-        try
-        {
+    public boolean sameJson(final String message, final JSONObject expected, final JSONObject actual, final boolean strict) {
+        try {
             JSONAssert.assertEquals(expected, actual, strict);
             return addAssertHistory(message, true, "assertSameJson", expected, actual);
-        } catch (final Throwable e)
-        {
+        } catch (final Throwable e) {
             final boolean rtn = addAssertHistory("", false, "assertSame", expected.toString(), actual.toString(), e);
-            if (getThrowExceptionOnFail())
-            {
+            if (getThrowExceptionOnFail()) {
                 throw new AssertionError(e);
             }
             return rtn;
         }
     }
-
+    
     /**
      * Same.
      *
@@ -264,11 +237,10 @@ public class VerboseAsserts
      * @param actual   the actual
      * @return true, if successful
      */
-    public boolean same(final Object expected, final Object actual)
-    {
+    public boolean same(final Object expected, final Object actual) {
         return same("", expected, actual);
     }
-
+    
     /**
      * Same.
      *
@@ -277,44 +249,38 @@ public class VerboseAsserts
      * @param actual   the actual
      * @return true, if successful
      */
-    public boolean same(final String message, final Object expected, final Object actual)
-    {
-        try
-        {
+    public boolean same(final String message, final Object expected, final Object actual) {
+        try {
             Assert.assertSame(message, expected, actual);
             return addAssertHistory(message, true, "assertSame", expected, actual);
-        } catch (final Throwable e)
-        {
+        } catch (final Throwable e) {
             final boolean rtn = addAssertHistory(message, false, "assertSame", expected, actual, e);
-            if (getThrowExceptionOnFail())
-            {
+            if (getThrowExceptionOnFail()) {
                 throw e;
             }
             return rtn;
         }
     }
-
+    
     /**
      * Fail.
      *
      * @return true, if successful
      */
-    public boolean fail()
-    {
+    public boolean fail() {
         return fail("");
     }
-
+    
     /**
      * Fail.
      *
      * @param message the message
      * @return true, if successful
      */
-    public boolean fail(final String message)
-    {
+    public boolean fail(final String message) {
         return fail(message, null);
     }
-
+    
     /**
      * Fail boolean.
      *
@@ -322,70 +288,62 @@ public class VerboseAsserts
      * @param throwable the throwable
      * @return the boolean
      */
-    public boolean fail(final String message, Throwable throwable)
-    {
-        try
-        {
+    public boolean fail(final String message, Throwable throwable) {
+        try {
             Assert.fail(message + (throwable != null ? " - throwable[" + throwable + "]" : ""));
             return addAssertHistory(message, false, "fail", "", "");
-        } catch (final Throwable e)
-        {
+        } catch (final Throwable e) {
             final boolean rtn = addAssertHistory(message, false, "fail", "", "", e);
-            if (getThrowExceptionOnFail())
-            {
+            if (getThrowExceptionOnFail()) {
                 throw e;
             }
             return rtn;
         }
     }
-
+    
     /**
      * Critical.
      *
      * @param message the message
      */
-    public void critical(final String message)
-    {
+    public void critical(final String message) {
         critical(message, null);
     }
-
+    
     /**
      * Critical failure.
      *
      * @param message   message string
      * @param throwable the throwable
      */
-    public void critical(final String message, final Throwable throwable)
-    {
+    public void critical(final String message, final Throwable throwable) {
         TS.log().fatal(Cli.BAR_LONG);
         TS.log().fatal(String.format("%s Critical Issue Occurred and test should be stopped! Message[%s]", Cli.BAR_WALL, message));
         TS.log().fatal(Cli.BAR_LONG);
         addAssertHistory(message, false, "critical", null, null, throwable);
     }
-
+    
     /**
      * Checks if is verify only.
      *
      * @return true, if is verify only
      */
-    public boolean isVerifyOnly()
-    {
+    public boolean isVerifyOnly() {
         return isVerifyOnly;
     }
-
+    
     /**
      * Sets the verify only.
      *
      * @param isVerifyOnly the new verify only
      * @return the verify only
      */
-    public VerboseAsserts setVerifyOnly(final boolean isVerifyOnly)
-    {
+    public VerboseAsserts setVerifyOnly(final boolean isVerifyOnly) {
         this.isVerifyOnly = isVerifyOnly;
         setThrowExceptionOnFail(false);
         return this;
     }
-
+    
     /**
      * Not null.
      *
@@ -393,34 +351,29 @@ public class VerboseAsserts
      * @param actual  the actual
      * @return true, if successful
      */
-    public boolean notNull(final String message, final Object actual)
-    {
-        try
-        {
+    public boolean notNull(final String message, final Object actual) {
+        try {
             Assert.assertNotNull(message, actual);
             return addAssertHistory(message, true, "assertNotNull", true, actual);
-        } catch (final Throwable e)
-        {
+        } catch (final Throwable e) {
             final boolean rtn = addAssertHistory(message, false, "assertNotNull", true, actual, e);
-            if (getThrowExceptionOnFail())
-            {
+            if (getThrowExceptionOnFail()) {
                 throw e;
             }
             return rtn;
         }
     }
-
+    
     /**
      * Not null.
      *
      * @param actual the actual
      * @return true, if successful
      */
-    public boolean notNull(final Object actual)
-    {
+    public boolean notNull(final Object actual) {
         return notNull("", actual);
     }
-
+    
     /**
      * Checks if is null.
      *
@@ -428,34 +381,29 @@ public class VerboseAsserts
      * @param actual  the actual
      * @return true, if is null
      */
-    public boolean isNull(final String message, final Object actual)
-    {
-        try
-        {
+    public boolean isNull(final String message, final Object actual) {
+        try {
             Assert.assertNull(message, actual);
             return addAssertHistory(message, true, "assertNull", null, actual);
-        } catch (final Throwable e)
-        {
+        } catch (final Throwable e) {
             final boolean rtn = addAssertHistory(message, false, "assertNull", null, actual, e);
-            if (getThrowExceptionOnFail())
-            {
+            if (getThrowExceptionOnFail()) {
                 throw e;
             }
             return rtn;
         }
     }
-
+    
     /**
      * Checks if is null.
      *
      * @param actual the actual
      * @return true, if is null
      */
-    public boolean isNull(final Object actual)
-    {
+    public boolean isNull(final Object actual) {
         return isNull("", actual);
     }
-
+    
     /**
      * Not same.
      *
@@ -463,11 +411,10 @@ public class VerboseAsserts
      * @param actual   the actual
      * @return true, if successful
      */
-    public boolean notSame(final Object expected, final Object actual)
-    {
+    public boolean notSame(final Object expected, final Object actual) {
         return notSame("", expected, actual);
     }
-
+    
     /**
      * Not same.
      *
@@ -476,23 +423,19 @@ public class VerboseAsserts
      * @param actual   the actual
      * @return true, if successful
      */
-    public boolean notSame(final String message, final Object expected, final Object actual)
-    {
-        try
-        {
+    public boolean notSame(final String message, final Object expected, final Object actual) {
+        try {
             Assert.assertNotSame(message, expected, actual);
             return addAssertHistory(message, true, "assertNotSame", expected, actual);
-        } catch (final Throwable e)
-        {
+        } catch (final Throwable e) {
             final boolean rtn = addAssertHistory(message, false, "assertNotSame", expected, actual, e);
-            if (getThrowExceptionOnFail())
-            {
+            if (getThrowExceptionOnFail()) {
                 throw e;
             }
             return rtn;
         }
     }
-
+    
     /**
      * Equals to ignore case.
      *
@@ -500,11 +443,10 @@ public class VerboseAsserts
      * @param actual   the actual
      * @return true, if successful
      */
-    public boolean equalsToIgnoreCase(final String expected, final String actual)
-    {
+    public boolean equalsToIgnoreCase(final String expected, final String actual) {
         return equalsToIgnoreCase("", expected, actual);
     }
-
+    
     /**
      * Equals to ignore case.
      * Converts to lowercase both using StringUtils, then does assertEquals.
@@ -515,24 +457,20 @@ public class VerboseAsserts
      * @param actual   the actual
      * @return true, if successful
      */
-    public boolean equalsToIgnoreCase(final String message, final String expected, final String actual)
-    {
-        try
-        {
+    public boolean equalsToIgnoreCase(final String message, final String expected, final String actual) {
+        try {
             Assert.assertEquals(message + " - expected[" + expected + "] == actual[" + actual + "]",
-                    StringUtils.lowerCase(expected), StringUtils.lowerCase(actual));
+                StringUtils.lowerCase(expected), StringUtils.lowerCase(actual));
             return addAssertHistory(message, true, "equalsToIgnoreCase", expected, actual);
-        } catch (final Throwable e)
-        {
+        } catch (final Throwable e) {
             final boolean rtn = addAssertHistory(message, false, "equalsToIgnoreCase", expected, actual, e);
-            if (getThrowExceptionOnFail())
-            {
+            if (getThrowExceptionOnFail()) {
                 throw e;
             }
             return rtn;
         }
     }
-
+    
     /**
      * Equals to multiline string boolean.
      *
@@ -541,28 +479,25 @@ public class VerboseAsserts
      * @param actual   the actual
      * @return the boolean
      */
-    public boolean equalsToMultilineString(final String message, final String expected, final String actual)
-    {
-        if (actual == null)
-        {
+    public boolean equalsToMultilineString(final String message, final String expected, final String actual) {
+        if (actual == null) {
             return isTrue("The Actual is null, checking to see if Expected is null, " +
-                    "else will fail and not go further for the assert.", (expected == null));
+                "else will fail and not go further for the assert.", (expected == null));
         }
         return new AssertCollections<String>(StringUtils.split(actual, System.lineSeparator()), this)
-                .equalsTo(StringUtils.split(expected, System.lineSeparator())).isPassed();
+            .equalsTo(StringUtils.split(expected, System.lineSeparator())).isPassed();
     }
-
+    
     /**
      * Assert file exists.
      *
      * @param actual the actual
      * @return true, if successful
      */
-    public boolean assertFileExists(final File actual)
-    {
+    public boolean assertFileExists(final File actual) {
         return assertFileExists("", actual);
     }
-
+    
     /**
      * Assert file exists.
      *
@@ -570,11 +505,10 @@ public class VerboseAsserts
      * @param actual  the actual
      * @return true, if successful
      */
-    public boolean assertFileExists(final String message, final File actual)
-    {
+    public boolean assertFileExists(final String message, final File actual) {
         return new AssertFile(actual, this).setMessage(message).exists().isPassed();
     }
-
+    
     /**
      * Equals to boolean.
      *
@@ -583,11 +517,10 @@ public class VerboseAsserts
      * @param actual   the actual
      * @return the boolean
      */
-    public boolean equalsTo(final String message, final String expected, final String actual)
-    {
+    public boolean equalsTo(final String message, final String expected, final String actual) {
         return new AssertStrings(actual, this).setMessage(message).equalsTo(expected).isPassed();
     }
-
+    
     /**
      * Equals.
      *
@@ -595,11 +528,10 @@ public class VerboseAsserts
      * @param actual   the actual
      * @return true, if successful
      */
-    public boolean equalsTo(final long expected, final long actual)
-    {
+    public boolean equalsTo(final long expected, final long actual) {
         return equalsTo("", expected, actual);
     }
-
+    
     /**
      * Equals.
      *
@@ -608,12 +540,11 @@ public class VerboseAsserts
      * @param actual   the actual
      * @return true, if successful
      */
-    public boolean equalsTo(final String message, final long expected, final long actual)
-    {
+    public boolean equalsTo(final String message, final long expected, final long actual) {
         return new AssertNumber<Long>(actual, this).setMessage(message)
-                .equalsTo(expected).isPassed();
+            .equalsTo(expected).isPassed();
     }
-
+    
     /**
      * Equals.
      *
@@ -622,11 +553,10 @@ public class VerboseAsserts
      * @param actual   the actual
      * @return true, if successful
      */
-    public boolean equalsTo(final String message, final Object[] expected, final Object[] actual)
-    {
+    public boolean equalsTo(final String message, final Object[] expected, final Object[] actual) {
         return new AssertCollections<Object>(actual).setMessage(message).equalsTo(expected).isPassed();
     }
-
+    
     /**
      * Equals.
      *
@@ -634,23 +564,19 @@ public class VerboseAsserts
      * @param actual   the actual
      * @return true, if successful
      */
-    public boolean equalsTo(final Object expected, final Object actual)
-    {
-        try
-        {
+    public boolean equalsTo(final Object expected, final Object actual) {
+        try {
             Assert.assertEquals(expected, actual);
             return addAssertHistory("", true, "assertEquals", expected, actual);
-        } catch (final Throwable e)
-        {
+        } catch (final Throwable e) {
             final boolean rtn = addAssertHistory("", false, "assertEquals", expected, actual, e);
-            if (getThrowExceptionOnFail())
-            {
+            if (getThrowExceptionOnFail()) {
                 throw e;
             }
             return rtn;
         }
     }
-
+    
     /**
      * Equals.
      *
@@ -660,23 +586,19 @@ public class VerboseAsserts
      * @param arg3     the arg3
      * @return true, if successful
      */
-    public boolean equalsTo(final String message, final double expected, final double actual, final double arg3)
-    {
-        try
-        {
+    public boolean equalsTo(final String message, final double expected, final double actual, final double arg3) {
+        try {
             Assert.assertEquals(message, expected, actual, arg3);
             return addAssertHistory(message, true, "assertEquals", expected, actual);
-        } catch (final Throwable e)
-        {
+        } catch (final Throwable e) {
             final boolean rtn = addAssertHistory(message, false, "assertEquals", expected, actual, e);
-            if (getThrowExceptionOnFail())
-            {
+            if (getThrowExceptionOnFail()) {
                 throw e;
             }
             return rtn;
         }
     }
-
+    
     /**
      * Equals.
      *
@@ -685,23 +607,19 @@ public class VerboseAsserts
      * @param actual   the actual
      * @return true, if successful
      */
-    public boolean equalsTo(final String message, final Object expected, final Object actual)
-    {
-        try
-        {
+    public boolean equalsTo(final String message, final Object expected, final Object actual) {
+        try {
             Assert.assertEquals(message, expected, actual);
             return addAssertHistory(message, true, "assertEquals", expected, actual);
-        } catch (final Throwable e)
-        {
+        } catch (final Throwable e) {
             final boolean rtn = addAssertHistory(message, false, "assertEquals", expected, actual, e);
-            if (getThrowExceptionOnFail())
-            {
+            if (getThrowExceptionOnFail()) {
                 throw e;
             }
             return rtn;
         }
     }
-
+    
     /**
      * Equals.
      *
@@ -709,23 +627,19 @@ public class VerboseAsserts
      * @param actual   the actual
      * @return true, if successful
      */
-    public boolean equalsTo(final Object[] expected, final Object[] actual)
-    {
-        try
-        {
+    public boolean equalsTo(final Object[] expected, final Object[] actual) {
+        try {
             Assert.assertArrayEquals(expected, actual);
             return addAssertHistory("", true, "assertEquals", expected, actual);
-        } catch (final Throwable e)
-        {
+        } catch (final Throwable e) {
             final boolean rtn = addAssertHistory("", false, "assertEquals", expected, actual, e);
-            if (getThrowExceptionOnFail())
-            {
+            if (getThrowExceptionOnFail()) {
                 throw e;
             }
             return rtn;
         }
     }
-
+    
     /**
      * Equals.
      *
@@ -734,23 +648,19 @@ public class VerboseAsserts
      * @param delta    the delta
      * @return true, if successful
      */
-    public boolean equalsTo(final float expected, final float actual, final float delta)
-    {
-        try
-        {
+    public boolean equalsTo(final float expected, final float actual, final float delta) {
+        try {
             Assert.assertEquals(expected, actual, delta);
             return addAssertHistory("", true, "assertEquals", expected, actual);
-        } catch (final Throwable e)
-        {
+        } catch (final Throwable e) {
             final boolean rtn = addAssertHistory("", false, "assertEquals", expected, actual, e);
-            if (getThrowExceptionOnFail())
-            {
+            if (getThrowExceptionOnFail()) {
                 throw e;
             }
             return rtn;
         }
     }
-
+    
     /**
      * Equals.
      *
@@ -759,23 +669,19 @@ public class VerboseAsserts
      * @param delta    the delta
      * @return true, if successful
      */
-    public boolean equalsTo(final double expected, final double actual, final double delta)
-    {
-        try
-        {
+    public boolean equalsTo(final double expected, final double actual, final double delta) {
+        try {
             Assert.assertEquals(expected, actual, delta);
             return addAssertHistory("", true, "assertEquals", expected, actual);
-        } catch (final Throwable e)
-        {
+        } catch (final Throwable e) {
             final boolean rtn = addAssertHistory("", false, "assertEquals", expected, actual, e);
-            if (getThrowExceptionOnFail())
-            {
+            if (getThrowExceptionOnFail()) {
                 throw e;
             }
             return rtn;
         }
     }
-
+    
     /**
      * Equals.
      *
@@ -785,23 +691,19 @@ public class VerboseAsserts
      * @param arg3     the arg3
      * @return true, if successful
      */
-    public boolean equalsTo(final String message, final float expected, final float actual, final float arg3)
-    {
-        try
-        {
+    public boolean equalsTo(final String message, final float expected, final float actual, final float arg3) {
+        try {
             Assert.assertEquals(message, expected, actual, arg3);
             return addAssertHistory(message, true, "assertEquals", expected, actual);
-        } catch (final Throwable e)
-        {
+        } catch (final Throwable e) {
             final boolean rtn = addAssertHistory(message, false, "assertEquals", expected, actual, e);
-            if (getThrowExceptionOnFail())
-            {
+            if (getThrowExceptionOnFail()) {
                 throw e;
             }
             return rtn;
         }
     }
-
+    
     /**
      * Equals.
      *
@@ -809,11 +711,10 @@ public class VerboseAsserts
      * @param actual   the actual
      * @return true, if successful
      */
-    public boolean equalsTo(final double expected, final double actual)
-    {
+    public boolean equalsTo(final double expected, final double actual) {
         return equalsTo("", expected, actual);
     }
-
+    
     /**
      * Equals.
      *
@@ -822,12 +723,11 @@ public class VerboseAsserts
      * @param actual   the actual
      * @return true, if successful
      */
-    public boolean equalsTo(final String message, final double expected, final double actual)
-    {
+    public boolean equalsTo(final String message, final double expected, final double actual) {
         return new AssertNumber<Double>(actual, this).setMessage(message)
-                .equalsTo(expected).isPassed();
+            .equalsTo(expected).isPassed();
     }
-
+    
     /**
      * Equals to with reflection boolean.
      *
@@ -835,11 +735,10 @@ public class VerboseAsserts
      * @param actual   the actual
      * @return the boolean
      */
-    public boolean equalsToWithReflection(final Object expected, final Object actual)
-    {
+    public boolean equalsToWithReflection(final Object expected, final Object actual) {
         return equalsToWithReflection("", expected, actual);
     }
-
+    
     /**
      * Equals to with reflection boolean.
      *
@@ -850,80 +749,98 @@ public class VerboseAsserts
      * @return the boolean
      */
     public boolean equalsToWithReflection(final String message, final Object expected, final Object actual,
-                                          ReflectionComparatorMode... modes)
-    {
-        try
-        {
+                                          ReflectionComparatorMode... modes) {
+        try {
             ReflectionAssert.assertReflectionEquals(message, expected, actual, modes);
             return addAssertHistory(message, true, "equalsToWithReflection", expected, actual);
-        } catch (final Throwable e)
-        {
+        } catch (final Throwable e) {
             final boolean rtn = addAssertHistory(message, false, "equalsToWithReflection", expected, actual, e);
             TS.step().action().createInfo("equalsToWithReflection", e.getMessage());
-            if (getThrowExceptionOnFail())
-            {
+            if (getThrowExceptionOnFail()) {
                 throw e;
             }
             return rtn;
         }
     }
-
+    
     /**
      * Unexpected exception.
      *
      * @param msg   the msg
      * @param error the error
      */
-    public void unExpectedException(final String msg, final Throwable error)
-    {
+    public void unExpectedException(final String msg, final Throwable error) {
         addAssertHistory(msg, false, "unExpectedException", "", msg, error);
     }
-
+    
     /**
      * Use Hamcrest matcher for assert.
+     * Deprecated as the param order is wrong, use the assertThat with the right order expected, actual.
      *
-     * @param <T>      generic type
-     * @param expected expected object
-     * @param matcher  Hamcrest matcher
+     * @param <T>     generic type
+     * @param actual  expected object
+     * @param matcher Hamcrest matcher
      */
-    public <T> void assertThat(final T expected, final Matcher<? super T> matcher)
-    {
-        assertThat("", expected, matcher);
+    @Deprecated
+    public <T> void assertThat(final T actual, final Matcher<? super T> matcher) {
+        assertThat("", matcher, actual);
     }
-
+    
+    /**
+     * Use Hamcrest matcher for assert.
+     * Deprecated as the param order is wrong, use the assertThat with the right order expected, actual.
+     *
+     * @param <T>     generic type
+     * @param message assert message
+     * @param actual  expected object
+     * @param matcher Hamcrest matcher
+     */
+    @Deprecated
+    public <T> void assertThat(final String message, final T actual, final Matcher<? super T> matcher) {
+        assertThat(message, matcher, actual);
+    }
+    
     /**
      * Use Hamcrest matcher for assert.
      *
-     * @param <T>      generic type
-     * @param message  assert message
-     * @param expected expected object
-     * @param matcher  Hamcrest matcher
+     * @param <T>             generic type
+     * @param expectedMatcher expected Hamcrest matcher to use
+     * @param actual          actual value to compare
      */
-    public <T> void assertThat(final String message, final T expected, final Matcher<? super T> matcher)
-    {
-        try
-        {
-            MatcherAssert.assertThat(message, expected, matcher);
-        } catch (AssertionError e)
-        {
-            addAssertHistory(message, false, "assertThat", expected, matcher, e);
-            if (getThrowExceptionOnFail())
-            {
+    public <T> boolean assertThat(final Matcher<? super T> expectedMatcher, final T actual) {
+        return assertThat("", expectedMatcher, actual);
+    }
+    
+    /**
+     * Use Hamcrest matcher for assert.
+     *
+     * @param <T>             generic type
+     * @param message         assert message
+     * @param expectedMatcher expected Hamcrest matcher to use
+     * @param actual          actual value to compare
+     */
+    public <T> boolean assertThat(final String message, final Matcher<? super T> expectedMatcher, final T actual) {
+        try {
+            MatcherAssert.assertThat(message, actual, expectedMatcher);
+            return addAssertHistory(message, true, "assertThat", expectedMatcher.toString(), actual);
+        } catch (AssertionError e) {
+            final boolean rtn = addAssertHistory(message, false, "assertThat", actual, expectedMatcher, e);
+            if (getThrowExceptionOnFail()) {
                 throw e;
             }
+            return rtn;
         }
     }
-
+    
     /**
      * Gets the throw exception on fail.
      *
      * @return the throw exception on fail
      */
-    public boolean getThrowExceptionOnFail()
-    {
+    public boolean getThrowExceptionOnFail() {
         return throwExceptionOnFail;
     }
-
+    
     /**
      * Checks if is false.
      *
@@ -931,34 +848,29 @@ public class VerboseAsserts
      * @param actual  the actual
      * @return true, if is false
      */
-    public boolean isFalse(final String message, final boolean actual)
-    {
-        try
-        {
+    public boolean isFalse(final String message, final boolean actual) {
+        try {
             Assert.assertFalse(message, actual);
             return addAssertHistory(message, true, "assertFalse", false, actual);
-        } catch (final Throwable e)
-        {
+        } catch (final Throwable e) {
             final boolean rtn = addAssertHistory(message, false, "assertFalse", false, actual, e);
-            if (getThrowExceptionOnFail())
-            {
+            if (getThrowExceptionOnFail()) {
                 throw e;
             }
             return rtn;
         }
     }
-
+    
     /**
      * Checks if is false.
      *
      * @param actual the actual
      * @return true, if is false
      */
-    public boolean isFalse(final boolean actual)
-    {
+    public boolean isFalse(final boolean actual) {
         return isFalse("", actual);
     }
-
+    
     /**
      * Checks if is true.
      *
@@ -966,34 +878,29 @@ public class VerboseAsserts
      * @param actual  the actual
      * @return true, if is true
      */
-    public boolean isTrue(final String message, final boolean actual)
-    {
-        try
-        {
+    public boolean isTrue(final String message, final boolean actual) {
+        try {
             Assert.assertTrue(message, actual);
             return addAssertHistory(message, true, "assertTrue", true, actual);
-        } catch (final Throwable e)
-        {
+        } catch (final Throwable e) {
             final boolean rtn = addAssertHistory(message, false, "assertTrue", true, actual, e);
-            if (getThrowExceptionOnFail())
-            {
+            if (getThrowExceptionOnFail()) {
                 throw e;
             }
             return rtn;
         }
     }
-
+    
     /**
      * Checks if is true.
      *
      * @param actual the actual
      * @return true, if is true
      */
-    public boolean isTrue(final boolean actual)
-    {
+    public boolean isTrue(final boolean actual) {
         return isTrue("", actual);
     }
-
+    
     /**
      * Not equals.
      *
@@ -1001,11 +908,10 @@ public class VerboseAsserts
      * @param actual   the actual
      * @return true, if successful
      */
-    public boolean notEquals(final Object expected, final Object actual)
-    {
+    public boolean notEquals(final Object expected, final Object actual) {
         return notEquals("", expected, actual);
     }
-
+    
     /**
      * Not equals.
      *
@@ -1014,23 +920,19 @@ public class VerboseAsserts
      * @param actual   the actual
      * @return true, if successful
      */
-    public boolean notEquals(final String message, final Object expected, final Object actual)
-    {
-        try
-        {
+    public boolean notEquals(final String message, final Object expected, final Object actual) {
+        try {
             Assert.assertNotEquals(message, expected, actual);
             return addAssertHistory(message, true, "assertNotEquals", expected, actual);
-        } catch (final Throwable e)
-        {
+        } catch (final Throwable e) {
             final boolean rtn = addAssertHistory(message, false, "assertNotEquals", expected, actual, e);
-            if (getThrowExceptionOnFail())
-            {
+            if (getThrowExceptionOnFail()) {
                 throw e;
             }
             return rtn;
         }
     }
-
+    
     /**
      * Not equals.
      *
@@ -1039,11 +941,10 @@ public class VerboseAsserts
      * @param delta      the delta
      * @return true, if successful
      */
-    public boolean notEquals(final float unexpected, final float actual, final float delta)
-    {
+    public boolean notEquals(final float unexpected, final float actual, final float delta) {
         return notEquals("", unexpected, actual, delta);
     }
-
+    
     /**
      * Not equals.
      *
@@ -1053,23 +954,19 @@ public class VerboseAsserts
      * @param delta    the delta
      * @return true, if successful
      */
-    public boolean notEquals(final String message, final float expected, final float actual, final float delta)
-    {
-        try
-        {
+    public boolean notEquals(final String message, final float expected, final float actual, final float delta) {
+        try {
             Assert.assertNotEquals(message, expected, actual, delta);
             return addAssertHistory(message, true, "assertNotEquals", expected, actual);
-        } catch (final Throwable e)
-        {
+        } catch (final Throwable e) {
             final boolean rtn = addAssertHistory(message, false, "assertNotEquals", expected, actual, e);
-            if (getThrowExceptionOnFail())
-            {
+            if (getThrowExceptionOnFail()) {
                 throw e;
             }
             return rtn;
         }
     }
-
+    
     /**
      * Not equals.
      *
@@ -1079,23 +976,19 @@ public class VerboseAsserts
      * @param delta    the delta
      * @return true, if successful
      */
-    public boolean notEquals(final String message, final double expected, final double actual, final double delta)
-    {
-        try
-        {
+    public boolean notEquals(final String message, final double expected, final double actual, final double delta) {
+        try {
             Assert.assertNotEquals(message, expected, actual, delta);
             return addAssertHistory(message, true, "assertNotEquals", expected, actual);
-        } catch (final Throwable e)
-        {
+        } catch (final Throwable e) {
             final boolean rtn = addAssertHistory(message, false, "assertNotEquals", expected, actual, e);
-            if (getThrowExceptionOnFail())
-            {
+            if (getThrowExceptionOnFail()) {
                 throw e;
             }
             return rtn;
         }
     }
-
+    
     /**
      * Not equals.
      *
@@ -1103,11 +996,10 @@ public class VerboseAsserts
      * @param actual   the actual
      * @return true, if successful
      */
-    public boolean notEquals(final long expected, final long actual)
-    {
+    public boolean notEquals(final long expected, final long actual) {
         return notEquals("", expected, actual);
     }
-
+    
     /**
      * Not equals.
      *
@@ -1116,11 +1008,10 @@ public class VerboseAsserts
      * @param delta      the delta
      * @return true, if successful
      */
-    public boolean notEquals(final double unexpected, final double actual, final double delta)
-    {
+    public boolean notEquals(final double unexpected, final double actual, final double delta) {
         return notEquals("", unexpected, actual, delta);
     }
-
+    
     /**
      * Not equals.
      *
@@ -1129,23 +1020,19 @@ public class VerboseAsserts
      * @param actual   the actual
      * @return true, if successful
      */
-    public boolean notEquals(final String message, final long expected, final long actual)
-    {
-        try
-        {
+    public boolean notEquals(final String message, final long expected, final long actual) {
+        try {
             Assert.assertNotEquals(message, expected, actual);
             return addAssertHistory(message, true, "assertNotEquals", expected, actual);
-        } catch (final Throwable e)
-        {
+        } catch (final Throwable e) {
             final boolean rtn = addAssertHistory(message, false, "assertNotEquals", expected, actual, e);
-            if (getThrowExceptionOnFail())
-            {
+            if (getThrowExceptionOnFail()) {
                 throw e;
             }
             return rtn;
         }
     }
-
+    
     /**
      * That.
      *
@@ -1154,11 +1041,10 @@ public class VerboseAsserts
      * @param matcher the matcher
      * @return true, if successful
      */
-    public <T> boolean that(final T actual, final Matcher<? super T> matcher)
-    {
+    public <T> boolean that(final T actual, final Matcher<? super T> matcher) {
         return that("", actual, matcher);
     }
-
+    
     /**
      * That.
      *
@@ -1168,23 +1054,19 @@ public class VerboseAsserts
      * @param matcher the matcher
      * @return true, if successful
      */
-    public <T> boolean that(final String message, final T actual, final Matcher<? super T> matcher)
-    {
-        try
-        {
+    public <T> boolean that(final String message, final T actual, final Matcher<? super T> matcher) {
+        try {
             Assert.assertThat(message, actual, matcher);
             return addAssertHistory(message, true, "assertThat", actual, matcher);
-        } catch (final Throwable e)
-        {
+        } catch (final Throwable e) {
             final boolean rtn = addAssertHistory(message, false, "assertThat", actual, matcher, e);
-            if (getThrowExceptionOnFail())
-            {
+            if (getThrowExceptionOnFail()) {
                 throw e;
             }
             return rtn;
         }
     }
-
+    
     /**
      * Array equals.
      *
@@ -1193,23 +1075,19 @@ public class VerboseAsserts
      * @param actual   the actual
      * @return true, if successful
      */
-    public boolean arrayEquals(final String message, final byte[] expected, final byte[] actual)
-    {
-        try
-        {
+    public boolean arrayEquals(final String message, final byte[] expected, final byte[] actual) {
+        try {
             Assert.assertArrayEquals(message, expected, actual);
             return addAssertHistory(message, true, "assertArrayEquals", expected, actual);
-        } catch (final Throwable e)
-        {
+        } catch (final Throwable e) {
             final boolean rtn = addAssertHistory(message, false, "assertArrayEquals", expected, actual, e);
-            if (getThrowExceptionOnFail())
-            {
+            if (getThrowExceptionOnFail()) {
                 throw e;
             }
             return rtn;
         }
     }
-
+    
     /**
      * Array equals.
      *
@@ -1217,11 +1095,10 @@ public class VerboseAsserts
      * @param actual   the actual
      * @return true, if successful
      */
-    public boolean arrayEquals(final byte[] expected, final byte[] actual)
-    {
+    public boolean arrayEquals(final byte[] expected, final byte[] actual) {
         return arrayEquals("", expected, actual);
     }
-
+    
     /**
      * Array equals.
      *
@@ -1230,23 +1107,19 @@ public class VerboseAsserts
      * @param actual   the actual
      * @return true, if successful
      */
-    public boolean arrayEquals(final String message, final char[] expected, final char[] actual)
-    {
-        try
-        {
+    public boolean arrayEquals(final String message, final char[] expected, final char[] actual) {
+        try {
             Assert.assertArrayEquals(message, expected, actual);
             return addAssertHistory(message, true, "assertArrayEquals", expected, actual);
-        } catch (final Throwable e)
-        {
+        } catch (final Throwable e) {
             final boolean rtn = addAssertHistory(message, false, "assertArrayEquals", expected, actual, e);
-            if (getThrowExceptionOnFail())
-            {
+            if (getThrowExceptionOnFail()) {
                 throw e;
             }
             return rtn;
         }
     }
-
+    
     /**
      * Array equals.
      *
@@ -1257,23 +1130,19 @@ public class VerboseAsserts
      * @return true, if successful
      */
     public boolean arrayEquals(final String message, final double[] expected, final double[] actual,
-                               final double arg3)
-    {
-        try
-        {
+                               final double arg3) {
+        try {
             Assert.assertArrayEquals(message, expected, actual, arg3);
             return addAssertHistory(message, true, "assertArrayEquals", expected, actual);
-        } catch (final Throwable e)
-        {
+        } catch (final Throwable e) {
             final boolean rtn = addAssertHistory(message, false, "assertArrayEquals", expected, actual, e);
-            if (getThrowExceptionOnFail())
-            {
+            if (getThrowExceptionOnFail()) {
                 throw e;
             }
             return rtn;
         }
     }
-
+    
     /**
      * Array equals.
      *
@@ -1282,23 +1151,19 @@ public class VerboseAsserts
      * @param actual   the actual
      * @return true, if successful
      */
-    public boolean arrayEquals(final String message, final Object[] expected, final Object[] actual)
-    {
-        try
-        {
+    public boolean arrayEquals(final String message, final Object[] expected, final Object[] actual) {
+        try {
             Assert.assertArrayEquals(message, expected, actual);
             return addAssertHistory(message, true, "assertArrayEquals", expected, actual);
-        } catch (final Throwable e)
-        {
+        } catch (final Throwable e) {
             final boolean rtn = addAssertHistory(message, false, "assertArrayEquals", expected, actual, e);
-            if (getThrowExceptionOnFail())
-            {
+            if (getThrowExceptionOnFail()) {
                 throw e;
             }
             return rtn;
         }
     }
-
+    
     /**
      * Array equals.
      *
@@ -1306,11 +1171,10 @@ public class VerboseAsserts
      * @param actual   the actual
      * @return true, if successful
      */
-    public boolean arrayEquals(final Object[] expected, final Object[] actual)
-    {
+    public boolean arrayEquals(final Object[] expected, final Object[] actual) {
         return arrayEquals("", expected, actual);
     }
-
+    
     /**
      * Array equals.
      *
@@ -1319,36 +1183,29 @@ public class VerboseAsserts
      * @param actual   the actual
      * @return true, if successful
      */
-    public boolean arrayEquals(final String message, final boolean[] expected, final boolean[] actual)
-    {
-        try
-        {
-            if (expected == null && actual == null)
-            {
+    public boolean arrayEquals(final String message, final boolean[] expected, final boolean[] actual) {
+        try {
+            if (expected == null && actual == null) {
                 TS.log().debug("Both expected and actual are null, so are equal");
-            } else
-            {
+            } else {
                 Assert.assertNotNull("Check if expected is null", expected);
                 Assert.assertNotNull("Check if actual is null", actual);
                 Assert.assertEquals("Assert that both arrays are the same size", expected.length, actual.length);
                 int index = 0;
-                for (boolean expectedValue : expected)
-                {
+                for (boolean expectedValue : expected) {
                     Assert.assertEquals(message + " - index[" + index + "]", expectedValue, actual[index++]);
                 }
             }
             return addAssertHistory(message, true, "assertArrayEquals", expected, actual);
-        } catch (final Throwable e)
-        {
+        } catch (final Throwable e) {
             final boolean rtn = addAssertHistory(message, false, "assertArrayEquals", expected, actual, e);
-            if (getThrowExceptionOnFail())
-            {
+            if (getThrowExceptionOnFail()) {
                 throw e;
             }
             return rtn;
         }
     }
-
+    
     /**
      * Array equals.
      *
@@ -1356,11 +1213,10 @@ public class VerboseAsserts
      * @param actual   the actual
      * @return true, if successful
      */
-    public boolean arrayEquals(final boolean[] expected, final boolean[] actual)
-    {
+    public boolean arrayEquals(final boolean[] expected, final boolean[] actual) {
         return arrayEquals("", expected, actual);
     }
-
+    
     /**
      * Array equals.
      *
@@ -1368,11 +1224,10 @@ public class VerboseAsserts
      * @param actual   the actual
      * @return true, if successful
      */
-    public boolean arrayEquals(final long[] expected, final long[] actual)
-    {
+    public boolean arrayEquals(final long[] expected, final long[] actual) {
         return arrayEquals("", expected, actual);
     }
-
+    
     /**
      * Array equals.
      *
@@ -1381,23 +1236,19 @@ public class VerboseAsserts
      * @param delta       the delta
      * @return true, if successful
      */
-    public boolean arrayEquals(final double[] expectedAry, final double[] actualAry, final double delta)
-    {
-        try
-        {
+    public boolean arrayEquals(final double[] expectedAry, final double[] actualAry, final double delta) {
+        try {
             Assert.assertArrayEquals(expectedAry, actualAry, delta);
             return addAssertHistory("", true, "assertArrayEquals", expectedAry, actualAry);
-        } catch (final AssertionError e)
-        {
+        } catch (final AssertionError e) {
             final boolean rtn = addAssertHistory("", false, "assertArrayEquals", expectedAry, actualAry, e);
-            if (getThrowExceptionOnFail())
-            {
+            if (getThrowExceptionOnFail()) {
                 throw e;
             }
             return rtn;
         }
     }
-
+    
     /**
      * Array equals.
      *
@@ -1408,23 +1259,19 @@ public class VerboseAsserts
      * @return true, if successful
      */
     public boolean arrayEquals(final String message, final float[] expecteds, final float[] actuals,
-                               final float delta)
-    {
-        try
-        {
+                               final float delta) {
+        try {
             Assert.assertArrayEquals(message, expecteds, actuals, delta);
             return addAssertHistory(message, true, "assertArrayEquals", expecteds, actuals);
-        } catch (final Throwable e)
-        {
+        } catch (final Throwable e) {
             final boolean rtn = addAssertHistory(message, false, "assertArrayEquals", expecteds, actuals, e);
-            if (getThrowExceptionOnFail())
-            {
+            if (getThrowExceptionOnFail()) {
                 throw e;
             }
             return rtn;
         }
     }
-
+    
     /**
      * Array equals.
      *
@@ -1433,11 +1280,10 @@ public class VerboseAsserts
      * @param delta     the delta
      * @return true, if successful
      */
-    public boolean arrayEquals(final float[] expecteds, final float[] actuals, final float delta)
-    {
+    public boolean arrayEquals(final float[] expecteds, final float[] actuals, final float delta) {
         return arrayEquals("", expecteds, actuals, delta);
     }
-
+    
     /**
      * Array equals.
      *
@@ -1445,11 +1291,10 @@ public class VerboseAsserts
      * @param actual   the actual
      * @return true, if successful
      */
-    public boolean arrayEquals(final char[] expected, final char[] actual)
-    {
+    public boolean arrayEquals(final char[] expected, final char[] actual) {
         return arrayEquals("", expected, actual);
     }
-
+    
     /**
      * Array equals.
      *
@@ -1458,23 +1303,19 @@ public class VerboseAsserts
      * @param actual   the actual
      * @return true, if successful
      */
-    public boolean arrayEquals(final String message, final short[] expected, final short[] actual)
-    {
-        try
-        {
+    public boolean arrayEquals(final String message, final short[] expected, final short[] actual) {
+        try {
             Assert.assertArrayEquals(message, expected, actual);
             return addAssertHistory(message, true, "assertArrayEquals", expected, actual);
-        } catch (final Throwable e)
-        {
+        } catch (final Throwable e) {
             final boolean rtn = addAssertHistory(message, false, "assertArrayEquals", expected, actual, e);
-            if (getThrowExceptionOnFail())
-            {
+            if (getThrowExceptionOnFail()) {
                 throw e;
             }
             return rtn;
         }
     }
-
+    
     /**
      * Array equals.
      *
@@ -1482,11 +1323,10 @@ public class VerboseAsserts
      * @param actual   the actual
      * @return true, if successful
      */
-    public boolean arrayEquals(final short[] expected, final short[] actual)
-    {
+    public boolean arrayEquals(final short[] expected, final short[] actual) {
         return arrayEquals("", expected, actual);
     }
-
+    
     /**
      * Array equals.
      *
@@ -1495,23 +1335,19 @@ public class VerboseAsserts
      * @param actual   the actual
      * @return true, if successful
      */
-    public boolean arrayEquals(final String message, final int[] expected, final int[] actual)
-    {
-        try
-        {
+    public boolean arrayEquals(final String message, final int[] expected, final int[] actual) {
+        try {
             Assert.assertArrayEquals(message, expected, actual);
             return addAssertHistory(message, true, "assertArrayEquals", expected, actual);
-        } catch (final Throwable e)
-        {
+        } catch (final Throwable e) {
             final boolean rtn = addAssertHistory(message, false, "assertArrayEquals", expected, actual, e);
-            if (getThrowExceptionOnFail())
-            {
+            if (getThrowExceptionOnFail()) {
                 throw e;
             }
             return rtn;
         }
     }
-
+    
     /**
      * Array equals.
      *
@@ -1519,11 +1355,10 @@ public class VerboseAsserts
      * @param actual   the actual
      * @return true, if successful
      */
-    public boolean arrayEquals(final int[] expected, final int[] actual)
-    {
+    public boolean arrayEquals(final int[] expected, final int[] actual) {
         return arrayEquals("", expected, actual);
     }
-
+    
     /**
      * Array equals.
      *
@@ -1532,23 +1367,19 @@ public class VerboseAsserts
      * @param actual   the actual
      * @return true, if successful
      */
-    public boolean arrayEquals(final String message, final long[] expected, final long[] actual)
-    {
-        try
-        {
+    public boolean arrayEquals(final String message, final long[] expected, final long[] actual) {
+        try {
             Assert.assertArrayEquals(message, expected, actual);
             return addAssertHistory(message, true, "assertArrayEquals", expected, actual);
-        } catch (final Throwable e)
-        {
+        } catch (final Throwable e) {
             final boolean rtn = addAssertHistory(message, false, "assertArrayEquals", expected, actual, e);
-            if (getThrowExceptionOnFail())
-            {
+            if (getThrowExceptionOnFail()) {
                 throw e;
             }
             return rtn;
         }
     }
-
+    
     /**
      * Checks if is empty.
      *
@@ -1556,54 +1387,43 @@ public class VerboseAsserts
      * @param objectToCheck the object to check
      * @return true, if is empty
      */
-    public boolean isEmpty(final String message, final Object objectToCheck)
-    {
-        if (notNull(message, objectToCheck))
-        {
+    public boolean isEmpty(final String message, final Object objectToCheck) {
+        if (notNull(message, objectToCheck)) {
             final boolean actual = isEmpty(objectToCheck);
             return isTrue(message + " - Is Empty[" + objectToCheck + "]", actual);
         }
         return false;
     }
-
+    
     /**
      * Checks if is empty.
      *
      * @param objectToCheck the object to check
      * @return true, if is empty
      */
-    private boolean isEmpty(final Object objectToCheck)
-    {
+    private boolean isEmpty(final Object objectToCheck) {
         Boolean actual = null;
-        if (objectToCheck instanceof String)
-        {
+        if (objectToCheck instanceof String) {
             actual = ((String) objectToCheck).length() == 0;
-        } else if (objectToCheck instanceof Object[])
-        {
+        } else if (objectToCheck instanceof Object[]) {
             actual = ((Object[]) objectToCheck).length == 0;
-        } else if (objectToCheck instanceof ArrayList)
-        {
+        } else if (objectToCheck instanceof ArrayList) {
             actual = ((ArrayList<?>) objectToCheck).isEmpty();
-        } else if (objectToCheck instanceof List)
-        {
+        } else if (objectToCheck instanceof List) {
             actual = ((List<?>) objectToCheck).isEmpty();
-        } else if (objectToCheck instanceof Set)
-        {
+        } else if (objectToCheck instanceof Set) {
             actual = ((Set<?>) objectToCheck).isEmpty();
-        } else if (objectToCheck instanceof HashMap)
-        {
+        } else if (objectToCheck instanceof HashMap) {
             actual = ((HashMap<?, ?>) objectToCheck).isEmpty();
         }
-        if (null != actual)
-        {
+        if (null != actual) {
             return actual;
-        } else
-        {
+        } else {
             throw new RuntimeException("Issue with object to Check for notEmpty Assert, object must be String, " +
-                    "ArrayList, Set, List or HashMap");
+                "ArrayList, Set, List or HashMap");
         }
     }
-
+    
     /**
      * Checks if is not empty.
      *
@@ -1611,16 +1431,14 @@ public class VerboseAsserts
      * @param objectToCheck the object to check
      * @return true, if is not empty
      */
-    public boolean isNotEmpty(final String message, final Object objectToCheck)
-    {
-        if (notNull(message, objectToCheck))
-        {
+    public boolean isNotEmpty(final String message, final Object objectToCheck) {
+        if (notNull(message, objectToCheck)) {
             final boolean actual = isEmpty(objectToCheck);
             return isFalse(message + " - Is Empty", actual);
         }
         return false;
     }
-
+    
     /**
      * Is greater than or equal to boolean.
      *
@@ -1629,11 +1447,10 @@ public class VerboseAsserts
      * @param actual               the actual
      * @return the boolean
      */
-    public boolean isGreaterThanOrEqualTo(String message, final Number valueToBeGreaterThan, final Number actual)
-    {
+    public boolean isGreaterThanOrEqualTo(String message, final Number valueToBeGreaterThan, final Number actual) {
         return isGreaterThan(message, valueToBeGreaterThan, actual, true);
     }
-
+    
     /**
      * Is greater than or equal to boolean.
      *
@@ -1642,12 +1459,11 @@ public class VerboseAsserts
      * @param actual               the actual
      * @return the boolean
      */
-    public boolean isGreaterThanOrEqualTo(String message, final BigDecimal valueToBeGreaterThan, final BigDecimal actual)
-    {
+    public boolean isGreaterThanOrEqualTo(String message, final BigDecimal valueToBeGreaterThan, final BigDecimal actual) {
         return isGreaterThan("", valueToBeGreaterThan, actual, true);
-
+        
     }
-
+    
     /**
      * Is greater than boolean.
      *
@@ -1657,11 +1473,10 @@ public class VerboseAsserts
      * @param allowEqualTo         the allow equal to
      * @return the boolean
      */
-    public boolean isGreaterThan(String message, final Number valueToBeGreaterThan, final Number actual, final boolean allowEqualTo)
-    {
+    public boolean isGreaterThan(String message, final Number valueToBeGreaterThan, final Number actual, final boolean allowEqualTo) {
         return isGreaterThan(message, new BigDecimal(valueToBeGreaterThan.toString()), new BigDecimal(actual.toString()), allowEqualTo);
     }
-
+    
     /**
      * Is greater than boolean.
      *
@@ -1670,11 +1485,10 @@ public class VerboseAsserts
      * @param actual               the actual
      * @return the boolean
      */
-    public boolean isGreaterThan(String message, final Number valueToBeGreaterThan, final Number actual)
-    {
+    public boolean isGreaterThan(String message, final Number valueToBeGreaterThan, final Number actual) {
         return isGreaterThan(message, valueToBeGreaterThan, actual, false);
     }
-
+    
     /**
      * Is greater than boolean.
      *
@@ -1683,41 +1497,34 @@ public class VerboseAsserts
      * @param actual               the actual
      * @return the boolean
      */
-    public boolean isGreaterThan(String message, final BigDecimal valueToBeGreaterThan, final BigDecimal actual)
-    {
+    public boolean isGreaterThan(String message, final BigDecimal valueToBeGreaterThan, final BigDecimal actual) {
         return isGreaterThan("", valueToBeGreaterThan, actual, false);
     }
-
+    
     private boolean isGreaterThan(String message, final BigDecimal valueToBeGreaterThan, final BigDecimal actual,
-                                  final boolean allowEqualTo)
-    {
+                                  final boolean allowEqualTo) {
         String assertMethod = (allowEqualTo ? "isGreaterThanOrEqualTo" : "isGreaterThan");
-        try
-        {
-
+        try {
+            
             notNull("Check valueToBeGreaterThan is not null", valueToBeGreaterThan);
             notNull("Check actual is not null", actual);
-
+            
             message = message + " - actual[" + actual.toPlainString() + "] " + assertMethod + " " + valueToBeGreaterThan.toPlainString();
-            if (allowEqualTo)
-            {
+            if (allowEqualTo) {
                 Assert.assertTrue(message, actual.compareTo(valueToBeGreaterThan) >= 0);
-            } else
-            {
+            } else {
                 Assert.assertTrue(message, actual.compareTo(valueToBeGreaterThan) > 0);
             }
             return addAssertHistory(message, true, assertMethod, valueToBeGreaterThan, actual);
-        } catch (final Throwable e)
-        {
+        } catch (final Throwable e) {
             final boolean rtn = addAssertHistory(message, false, assertMethod, valueToBeGreaterThan, actual, e);
-            if (getThrowExceptionOnFail())
-            {
+            if (getThrowExceptionOnFail()) {
                 throw e;
             }
             return rtn;
         }
     }
-
+    
     /**
      * Is less than or equal to boolean.
      *
@@ -1726,11 +1533,10 @@ public class VerboseAsserts
      * @param actual            the actual
      * @return the boolean
      */
-    public boolean isLessThanOrEqualTo(String message, final Number valueToBeLessThan, final Number actual)
-    {
+    public boolean isLessThanOrEqualTo(String message, final Number valueToBeLessThan, final Number actual) {
         return isLessThan(message, valueToBeLessThan, actual, true);
     }
-
+    
     /**
      * Is less than or equal to boolean.
      *
@@ -1739,11 +1545,10 @@ public class VerboseAsserts
      * @param actual            the actual
      * @return the boolean
      */
-    public boolean isLessThanOrEqualTo(String message, final BigDecimal valueToBeLessThan, final BigDecimal actual)
-    {
+    public boolean isLessThanOrEqualTo(String message, final BigDecimal valueToBeLessThan, final BigDecimal actual) {
         return isLessThan(message, valueToBeLessThan, actual, true);
     }
-
+    
     /**
      * Is less than boolean.
      *
@@ -1752,11 +1557,10 @@ public class VerboseAsserts
      * @param actual            the actual
      * @return the boolean
      */
-    public boolean isLessThan(String message, final Number valueToBeLessThan, final Number actual)
-    {
+    public boolean isLessThan(String message, final Number valueToBeLessThan, final Number actual) {
         return isLessThan(message, valueToBeLessThan, actual, false);
     }
-
+    
     /**
      * Is less than boolean.
      *
@@ -1766,11 +1570,10 @@ public class VerboseAsserts
      * @param allowEqualTo      the allow equal to
      * @return the boolean
      */
-    public boolean isLessThan(String message, final Number valueToBeLessThan, final Number actual, final boolean allowEqualTo)
-    {
+    public boolean isLessThan(String message, final Number valueToBeLessThan, final Number actual, final boolean allowEqualTo) {
         return isLessThan(message, new BigDecimal(valueToBeLessThan.toString()), new BigDecimal(actual.toString()), allowEqualTo);
     }
-
+    
     /**
      * Is less than boolean.
      *
@@ -1779,11 +1582,10 @@ public class VerboseAsserts
      * @param actual            the actual
      * @return the boolean
      */
-    public boolean isLessThan(String message, final BigDecimal valueToBeLessThan, final BigDecimal actual)
-    {
+    public boolean isLessThan(String message, final BigDecimal valueToBeLessThan, final BigDecimal actual) {
         return isLessThan(message, valueToBeLessThan, actual, false);
     }
-
+    
     /**
      * Is less than boolean.
      *
@@ -1793,56 +1595,48 @@ public class VerboseAsserts
      * @param allowEqualTo      the allow equal to
      * @return the boolean
      */
-    public boolean isLessThan(String message, final BigDecimal valueToBeLessThan, final BigDecimal actual, final boolean allowEqualTo)
-    {
+    public boolean isLessThan(String message, final BigDecimal valueToBeLessThan, final BigDecimal actual, final boolean allowEqualTo) {
         String assertMethod = (allowEqualTo ? "isLessThanOrEqualTo" : "isLessThan");
-
+        
         notNull("Check valueToBeLessThan is not null", valueToBeLessThan);
         notNull("Check actual is not null", actual);
-
-        try
-        {
+        
+        try {
             message = message + " - actual[" + actual.toPlainString() + "] " + assertMethod + " " + valueToBeLessThan.toPlainString();
-            if (allowEqualTo)
-            {
+            if (allowEqualTo) {
                 Assert.assertTrue(message, actual.compareTo(valueToBeLessThan) <= 0);
-            } else
-            {
+            } else {
                 Assert.assertTrue(message, actual.compareTo(valueToBeLessThan) < 0);
             }
             return addAssertHistory(message, true, assertMethod, valueToBeLessThan, actual);
-        } catch (final Throwable e)
-        {
+        } catch (final Throwable e) {
             final boolean rtn = addAssertHistory(message, false, assertMethod, valueToBeLessThan, actual, e);
-            if (getThrowExceptionOnFail())
-            {
+            if (getThrowExceptionOnFail()) {
                 throw e;
             }
             return rtn;
         }
     }
-
+    
     /**
      * ************************************************************************* ***********.
      *
      * @return true, if successful
      */
-    public boolean pass()
-    {
+    public boolean pass() {
         return pass("");
     }
-
+    
     /**
      * Pass.
      *
      * @param message the message
      * @return true, if successful
      */
-    public boolean pass(final String message)
-    {
+    public boolean pass(final String message) {
         return addAssertHistory(message, true, "pass", true, true, null);
     }
-
+    
     /**
      * Adds the assert history.
      *
@@ -1854,11 +1648,10 @@ public class VerboseAsserts
      * @return true, if successful
      */
     public boolean addAssertHistory(final String message, final Boolean status, final String assertMethod,
-                                    final Object expected, final Object actual)
-    {
+                                    final Object expected, final Object actual) {
         return addAssertHistory(message, status, assertMethod, expected, actual, null);
     }
-
+    
     /**
      * Adds the assert history.
      *
@@ -1871,76 +1664,68 @@ public class VerboseAsserts
      * @return true, if successful
      */
     public boolean addAssertHistory(final String message, final Boolean status, final String assertMethod,
-                                    final Object expected, final Object actual, final Throwable exception)
-    {
-        if (isVerifyOnly())
-        {
+                                    final Object expected, final Object actual, final Throwable exception) {
+        if (isVerifyOnly()) {
             TS.step().action().createVerifyResult(message, status, assertMethod, expected, actual, exception, true);
-        } else
-        {
+        } else {
             TS.step().action().createAssertResult(message, status, assertMethod, expected, actual, exception, true);
         }
-
+        
         return status;
     }
-
+    
     /**
      * Checks if is throw exception on fail.
      *
      * @return true, if is throw exception on fail
      */
-    public boolean isThrowExceptionOnFail()
-    {
+    public boolean isThrowExceptionOnFail() {
         return getThrowExceptionOnFail();
     }
-
+    
     /**
      * Sets the throw exception on fail.
      *
      * @param throwExceptionOnFail the new throw exception on fail
      * @return the throw exception on fail
      */
-    public VerboseAsserts setThrowExceptionOnFail(final boolean throwExceptionOnFail)
-    {
+    public VerboseAsserts setThrowExceptionOnFail(final boolean throwExceptionOnFail) {
         this.throwExceptionOnFail = throwExceptionOnFail;
         return this;
     }
-
+    
     /**
      * Only verify.
      *
      * @return the verbose asserts
      */
-    public VerboseAsserts onlyVerify()
-    {
+    public VerboseAsserts onlyVerify() {
         this.recordSteps = false;
         this.throwExceptionOnFail = false;
         this.setVerifyOnly(true);
         return this;
     }
-
+    
     /**
      * Checks if is record steps.
      *
      * @return true, if is record steps
      */
-    public boolean isRecordSteps()
-    {
+    public boolean isRecordSteps() {
         return recordSteps;
     }
-
+    
     /**
      * Sets the record steps.
      *
      * @param recordSteps the new record steps
      * @return the record steps
      */
-    public VerboseAsserts setRecordSteps(final boolean recordSteps)
-    {
+    public VerboseAsserts setRecordSteps(final boolean recordSteps) {
         this.recordSteps = recordSteps;
         return this;
     }
-
+    
     /**
      * Given assert collections.
      *
@@ -1948,11 +1733,10 @@ public class VerboseAsserts
      * @param actual the actual
      * @return the assert collections
      */
-    public <H> AssertCollections given(final H[] actual)
-    {
+    public <H> AssertCollections given(final H[] actual) {
         return new AssertCollections<>(actual, this);
     }
-
+    
     /**
      * Given assert collections.
      *
@@ -1960,11 +1744,10 @@ public class VerboseAsserts
      * @param actual the actual
      * @return the assert collections
      */
-    public <H> AssertCollections given(final Collection<H> actual)
-    {
+    public <H> AssertCollections given(final Collection<H> actual) {
         return new AssertCollections<>(actual, this);
     }
-
+    
     /**
      * Given assert maps.
      *
@@ -1973,22 +1756,20 @@ public class VerboseAsserts
      * @param actual the actual
      * @return the assert maps
      */
-    public <T, H> AssertMaps given(final AbstractMap<T, H> actual)
-    {
+    public <T, H> AssertMaps given(final AbstractMap<T, H> actual) {
         return new AssertMaps<>(actual, this);
     }
-
+    
     /**
      * Given assert strings.
      *
      * @param actual the actual
      * @return the assert strings
      */
-    public AssertStrings given(final String actual)
-    {
+    public AssertStrings given(final String actual) {
         return new AssertStrings(actual, this);
     }
-
+    
     /**
      * Given assert number.
      *
@@ -1996,89 +1777,77 @@ public class VerboseAsserts
      * @param actual the actual
      * @return the assert number
      */
-    public <T extends Number & Comparable<T>> AssertNumber<T> given(final T actual)
-    {
+    public <T extends Number & Comparable<T>> AssertNumber<T> given(final T actual) {
         return new AssertNumber<T>(actual, this);
     }
-
+    
     /**
      * Look for an array of strings in standard error.
      *
-     * @param code the executable code that will write to standard err.
+     * @param code          the executable code that will write to standard err.
      * @param textToContain the array of strings to look for
      * @return true if each string is found, false otherwise
      */
-    public boolean assertSystemErrContains(final Runnable code, final String... textToContain)
-    {
+    public boolean assertSystemErrContains(final Runnable code, final String... textToContain) {
         String content = null;
-        try (SystemOutCapture systemOutCapture = new SystemOutCapture().start())
-        {
+        try (SystemOutCapture systemOutCapture = new SystemOutCapture().start()) {
             code.run();
             content = systemOutCapture.getSystemErr();
         }
         return assertContains(content, textToContain);
     }
-
+    
     /**
      * Look for an array of strings in standard output.
      *
-     * @param code the executable code that will write to standard out.
+     * @param code          the executable code that will write to standard out.
      * @param textToContain the array of strings to look for
      * @return true if each string is found, false otherwise
      */
-    public boolean assertSystemOutContains(final Runnable code, final String... textToContain)
-    {
+    public boolean assertSystemOutContains(final Runnable code, final String... textToContain) {
         String content = null;
-        try (SystemOutCapture systemOutCapture = new SystemOutCapture().start())
-        {
+        try (SystemOutCapture systemOutCapture = new SystemOutCapture().start()) {
             code.run();
             content = systemOutCapture.getSystemOut();
         }
         return assertContains(content, textToContain);
     }
-
+    
     /**
      * Look for an array of strings in both standard output and standard error.
      *
-     * @param code the executable code that will write to standard out/err.
+     * @param code          the executable code that will write to standard out/err.
      * @param textToContain the array of strings to look for
      * @return true if each string is found, false otherwise
      */
-    public boolean assertSystemOutErrContains(final Runnable code, final String... textToContain)
-    {
+    public boolean assertSystemOutErrContains(final Runnable code, final String... textToContain) {
         String content = null;
-        try (SystemOutCapture systemOutCapture = new SystemOutCapture().start())
-        {
+        try (SystemOutCapture systemOutCapture = new SystemOutCapture().start()) {
             code.run();
             content = systemOutCapture.getSystemOutErr();
         }
         return assertContains(content, textToContain);
     }
-
-    private boolean assertContains(final String content, final String[] textToContain)
-    {
-        if (textToContain != null)
-        {
+    
+    private boolean assertContains(final String content, final String[] textToContain) {
+        if (textToContain != null) {
             AssertStrings assertStrings = new AssertStrings(content);
-            for (final String containString : textToContain)
-            {
+            for (final String containString : textToContain) {
                 assertStrings.contains(containString);
             }
             return assertStrings.isPassed();
         }
         return false;
     }
-
-    public boolean contains(final String message, final String stringToCheck, final String expectedStringToContain)
-    {
+    
+    public boolean contains(final String message, final String stringToCheck, final String expectedStringToContain) {
         return new AssertStrings(stringToCheck, this).setMessage(message)
-                .contains(expectedStringToContain).isPassed();
+            .contains(expectedStringToContain).isPassed();
     }
-
-    public boolean startsWith(final String message, final String stringToCheck, final String expectedStringToContain)
-    {
+    
+    public boolean startsWith(final String message, final String stringToCheck, final String expectedStringToContain) {
         return new AssertStrings(stringToCheck, this).setMessage(message)
-                .startsWith(expectedStringToContain).isPassed();
+            .startsWith(expectedStringToContain).isPassed();
     }
-
+    
 }

--- a/testah-junit/src/test/java/org/testah/driver/http/response/ResponseDtoTest.java
+++ b/testah-junit/src/test/java/org/testah/driver/http/response/ResponseDtoTest.java
@@ -340,7 +340,7 @@ public class ResponseDtoTest {
         new AssertFile(getResponse.writeResponseInfoFile(true)).contentContains(
             "{\"args\":{},\"headers\":{",
             "\"host\":\"postman-echo.com\",",
-            "\"accept-encoding\":\"gzip,deflate\",",
+            "\"accept-encoding\":\"gzip,deflate\"",
             "\"user-agent\":\"Apache-HttpClient/",
             "\"url\":\"https://postman-echo.com/get\"");
     }

--- a/testah-junit/src/test/java/org/testah/util/StringMaskingTest.java
+++ b/testah-junit/src/test/java/org/testah/util/StringMaskingTest.java
@@ -118,33 +118,31 @@ public class StringMaskingTest
         final String str2 = "aaabbbccc2";
         final String str3 = "aaabbbccc3";
         final String str4 = "aaabbccc";
-        final String str5 = "eastusma";
-        final String str6 = "az.eastus.region";
-        final String str7 = "eagleinvsys.org";
+        final String str6 = "az.abc.region";
+        final String str7 = "abc.org";
         final String str8 = "in 2019-01-01";
         final String str9 = "2018-01-01";
-        final String str10 = "eagleinvsys.com";
-        final String regex1 = ".*eastus.*";
-        final String regex2 = ".*eagle.*";
+        final String str10 = "abcdef.com";
+        final String regex1 = ".*abc.*";
+        final String regex2 = ".*abc.*";
         final String regex3 = ".*[0-9]{4}-[0-9]{2}-[0-9]{2}.*";
 
         StringMaskingConfig.INSTANCE.createInstance(7, 2, 2);
         StringMasking.INSTANCE.createInstance()
                 .addLiteralExemptions(str0, str1, str2)
                 .addRegexExemptions(regex1, regex2, regex3)
-                .addBulk(str0, str1, str2, str3, str4, str5, str6, str7, str8, str9)
+                .addBulk(str0, str1, str2, str3, str4, str6, str7, str8, str9)
                 .add(str10);
         assertEquals(str0, StringMasking.INSTANCE.getInstance().getValue(str0));
         assertEquals(str1, StringMasking.INSTANCE.getInstance().getValue(str1));
         assertEquals(str2, StringMasking.INSTANCE.getInstance().getValue(str2));
         assertEquals("aa***c3", StringMasking.INSTANCE.getInstance().getValue(str3));
         assertEquals("aa***cc", StringMasking.INSTANCE.getInstance().getValue(str4));
-        assertEquals(str5, StringMasking.INSTANCE.getInstance().getValue(str5));
         assertEquals(str6, StringMasking.INSTANCE.getInstance().getValue(str6));
         assertEquals(str7, StringMasking.INSTANCE.getInstance().getValue(str7));
         assertEquals(str8, StringMasking.INSTANCE.getInstance().getValue(str8));
         assertEquals(str9, StringMasking.INSTANCE.getInstance().getValue(str9));
-        assertEquals("ea***om", StringMasking.INSTANCE.getInstance().getValue(str10));
+        assertEquals("ab***om", StringMasking.INSTANCE.getInstance().getValue(str10));
 
         assertEquals(Sets.newHashSet(str0, str1, str2, "true", "TRUE", "false", "FALSE"),
                 StringMasking.INSTANCE.getInstance().getLiteralExemptions());


### PR DESCRIPTION
AssertThat method was not capturing positive history for the method, and the order of params was incorrect. Added new method signatures and deprecated the old ones to maintain backwards compatibility.