### PR TITLE
filter testplans with metadata added from testcases

### DIFF
--- a/testah-junit/.gitignore
+++ b/testah-junit/.gitignore
@@ -6,3 +6,4 @@ download*
 drivers
 testah-junit.ipr
 testah-junit.iws
+summaryResults.json

--- a/testah-junit/gradle.properties
+++ b/testah-junit/gradle.properties
@@ -1,3 +1,3 @@
 group=org.testah
-version=2.4.0
+version=2.4.1
 junitPlatformVersion=5.6.2

--- a/testah-junit/gradle.properties
+++ b/testah-junit/gradle.properties
@@ -1,3 +1,3 @@
 group=org.testah
-version=2.4.1
+version=2.4.2
 junitPlatformVersion=5.6.2

--- a/testah-junit/src/main/java/org/testah/framework/cli/Cli.java
+++ b/testah-junit/src/main/java/org/testah/framework/cli/Cli.java
@@ -44,7 +44,7 @@ public class Cli {
      * The Constant version.
      */
 
-    public static final String version = "2.4.0";
+    public static final String version = "2.4.1";
 
     /**
      * The Constant BAR_LONG.

--- a/testah-junit/src/main/java/org/testah/framework/cli/Cli.java
+++ b/testah-junit/src/main/java/org/testah/framework/cli/Cli.java
@@ -44,7 +44,7 @@ public class Cli {
      * The Constant version.
      */
 
-    public static final String version = "2.4.1";
+    public static final String version = "2.4.2";
 
     /**
      * The Constant BAR_LONG.

--- a/testah-junit/src/main/java/org/testah/framework/dto/TestPlanAnnotationDto.java
+++ b/testah-junit/src/main/java/org/testah/framework/dto/TestPlanAnnotationDto.java
@@ -1,16 +1,24 @@
 package org.testah.framework.dto;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.NotImplementedException;
 import org.testah.client.enums.TestType;
+import org.testah.framework.annotations.TestCase;
+import org.testah.framework.annotations.TestCaseJUnit5;
 import org.testah.framework.annotations.TestPlan;
 import org.testah.framework.annotations.TestPlanJUnit5;
 import org.testah.framework.testPlan.TestSystem;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.HashSet;
 
 public class TestPlanAnnotationDto {
 
+    public static final boolean applyTestCaseAnnotations = true;
+
+    Class testClass;
     private int id = -1;
     private String name = "";
     private String description = "";
@@ -28,7 +36,8 @@ public class TestPlanAnnotationDto {
 
     }
 
-    private TestPlanAnnotationDto(TestPlan testPlan) {
+    private TestPlanAnnotationDto(TestPlan testPlan, Class testClass) {
+        this.testClass = testClass;
         this.id = testPlan.id();
         this.name = testPlan.name();
         this.description = testPlan.description();
@@ -43,7 +52,8 @@ public class TestPlanAnnotationDto {
         this.owner = testPlan.owner();
     }
 
-    private TestPlanAnnotationDto(TestPlanJUnit5 testPlan) {
+    private TestPlanAnnotationDto(TestPlanJUnit5 testPlan, Class testClass) {
+        this.testClass = testClass;
         this.id = testPlan.id();
         this.name = testPlan.name();
         this.description = testPlan.description();
@@ -67,7 +77,7 @@ public class TestPlanAnnotationDto {
      */
     public static TestPlanAnnotationDto create(final Class testClass) {
         if (testClass != null) {
-            return create(TestSystem.DEFAULT_TESTPLAN_JUNIT_VERSION, testClass.getAnnotations());
+            return create(TestSystem.DEFAULT_TESTPLAN_JUNIT_VERSION, testClass, testClass.getAnnotations());
         }
         return null;
     }
@@ -81,37 +91,38 @@ public class TestPlanAnnotationDto {
      */
     public static TestPlanAnnotationDto create(final int junitVersion, final Class testClass) {
         if (testClass != null) {
-            return create(junitVersion, testClass.getAnnotations());
+            return create(junitVersion, testClass, testClass.getAnnotations());
         }
         return null;
     }
-
 
     /**
      * Create TestPlanAnnotationDto from a testPlan annotation.
      * Uses TestSystem.DEFAULT_TESTPLAN_JUNIT_VERSION as default for JUnit version.
      *
+     * @param testClass test class for the testplan.
      * @param testPlans testPlan annotation.
      * @return return new TestPlanAnnotationDto.
      */
-    public static TestPlanAnnotationDto create(Annotation... testPlans) {
-        return create(TestSystem.DEFAULT_TESTPLAN_JUNIT_VERSION, testPlans);
+    public static TestPlanAnnotationDto create(final Class testClass, Annotation... testPlans) {
+        return create(TestSystem.DEFAULT_TESTPLAN_JUNIT_VERSION, testClass, testPlans);
     }
 
     /**
      * Create TestPlanAnnotationDto from a testPlan annotation.
      *
+     * @param testClass    test class for the testplan.
      * @param junitVersion junit version being used.
      * @param testPlans    testPlan annotation.
      * @return return new TestPlanAnnotationDto.
      */
-    public static TestPlanAnnotationDto create(int junitVersion, Annotation... testPlans) {
+    public static TestPlanAnnotationDto create(int junitVersion, final Class testClass, Annotation... testPlans) {
         if (testPlans != null) {
             for (Annotation testPlan : testPlans) {
                 if (testPlan instanceof TestPlan) {
-                    return new TestPlanAnnotationDto((TestPlan) testPlan);
+                    return new TestPlanAnnotationDto((TestPlan) testPlan, testClass).mergeWithTestCases();
                 } else if (testPlan instanceof TestPlanJUnit5) {
-                    return new TestPlanAnnotationDto((TestPlanJUnit5) testPlan);
+                    return new TestPlanAnnotationDto((TestPlanJUnit5) testPlan, testClass).mergeWithTestCasesJUnit5();
                 }
             }
         }
@@ -167,6 +178,54 @@ public class TestPlanAnnotationDto {
 
     public String owner() {
         return owner;
+    }
+
+    /**
+     * Merge testcase meta data into the testplan for filtering. JUnit4.
+     * @return returns the merged testplan meta.
+     */
+    public TestPlanAnnotationDto mergeWithTestCases() {
+        if (testClass != null && testClass.getMethods().length > 0) {
+            for (Method test : testClass.getMethods()) {
+                TestCase testCase = test.getAnnotation(TestCase.class);
+                if (testCase != null) {
+                    this.components = appendAndDedupArray(this.components(), testCase.components());
+                    this.devices = appendAndDedupArray(this.devices(), testCase.devices());
+                    this.relatedIds = appendAndDedupArray(this.relatedIds(), testCase.relatedIds());
+                    this.relatedLinks = appendAndDedupArray(this.relatedLinks(), testCase.relatedLinks());
+                    this.runTypes = appendAndDedupArray(this.runTypes(), testCase.runTypes());
+                    this.platforms = appendAndDedupArray(this.platforms(), testCase.platforms());
+                    this.tags = appendAndDedupArray(this.tags(), testCase.tags());
+                }
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Merge testcase meta data into the testplan for filtering. JUnit5.
+     * @return returns the merged testplan meta.
+     */
+    public TestPlanAnnotationDto mergeWithTestCasesJUnit5() {
+        if (testClass != null && testClass.getMethods().length > 0) {
+            for (Method test : testClass.getMethods()) {
+                TestCaseJUnit5 testCaseJUnit5 = test.getAnnotation(TestCaseJUnit5.class);
+                if (testCaseJUnit5 != null) {
+                    this.components = appendAndDedupArray(this.components(), testCaseJUnit5.components());
+                    this.devices = appendAndDedupArray(this.devices(), testCaseJUnit5.devices());
+                    this.relatedIds = appendAndDedupArray(this.relatedIds(), testCaseJUnit5.relatedIds());
+                    this.relatedLinks = appendAndDedupArray(this.relatedLinks(), testCaseJUnit5.relatedLinks());
+                    this.runTypes = appendAndDedupArray(this.runTypes(), testCaseJUnit5.runTypes());
+                    this.platforms = appendAndDedupArray(this.components(), testCaseJUnit5.components());
+                    this.tags = appendAndDedupArray(this.tags(), testCaseJUnit5.tags());
+                }
+            }
+        }
+        return this;
+    }
+
+    public static String[] appendAndDedupArray(final String[] array1, final String[] array2) {
+        return new HashSet<String>(Arrays.asList(ArrayUtils.addAll(array1, array2))).toArray(new String[0]);
     }
 
 }

--- a/testah-junit/src/main/java/org/testah/framework/testPlan/Junit5TestPlanSupport.java
+++ b/testah-junit/src/main/java/org/testah/framework/testPlan/Junit5TestPlanSupport.java
@@ -1,13 +1,6 @@
 package org.testah.framework.testPlan;
 
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.AfterEachCallback;
-import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.BeforeEachCallback;
-import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.api.extension.TestWatcher;
+import org.junit.jupiter.api.extension.*;
 import org.junit.runner.Description;
 import org.testah.TS;
 import org.testah.framework.annotations.TestCaseJUnit5;
@@ -24,7 +17,7 @@ import java.util.Optional;
  * and the test methods with @TestCaseJUnit5
  */
 public class Junit5TestPlanSupport implements BeforeTestExecutionCallback, AfterTestExecutionCallback,
-    AfterAllCallback, BeforeAllCallback, BeforeEachCallback, AfterEachCallback, TestWatcher {
+        AfterAllCallback, BeforeAllCallback, BeforeEachCallback, AfterEachCallback, TestWatcher {
 
     public static final int JUNIT_VERSION = 5;
 
@@ -37,8 +30,9 @@ public class Junit5TestPlanSupport implements BeforeTestExecutionCallback, After
     public void beforeTestExecution(ExtensionContext context) throws Exception {
         Description description = getDescription(context);
         TS.testSystem().starting(description,
-            TestPlanAnnotationDto.create(JUNIT_VERSION, description.getTestClass().getAnnotation(TestPlanJUnit5.class)),
-            TestCaseAnnotationDto.create(description.getAnnotation(TestCaseJUnit5.class)), JUNIT_VERSION);
+                TestPlanAnnotationDto.create(JUNIT_VERSION, description.getTestClass(),
+                        description.getTestClass().getAnnotation(TestPlanJUnit5.class)),
+                TestCaseAnnotationDto.create(description.getAnnotation(TestCaseJUnit5.class)), JUNIT_VERSION);
     }
 
     @Override
@@ -60,8 +54,9 @@ public class Junit5TestPlanSupport implements BeforeTestExecutionCallback, After
     public void beforeEach(ExtensionContext context) throws Exception {
         Description description = getDescription(context);
         TS.testSystem().filterTest(description,
-            TestPlanAnnotationDto.create(JUNIT_VERSION, description.getTestClass().getAnnotation(TestPlanJUnit5.class)),
-            TestCaseAnnotationDto.create(description.getAnnotation(TestCaseJUnit5.class)));
+                TestPlanAnnotationDto.create(JUNIT_VERSION, description.getTestClass(),
+                        description.getTestClass().getAnnotation(TestPlanJUnit5.class)),
+                TestCaseAnnotationDto.create(description.getAnnotation(TestCaseJUnit5.class)));
     }
 
     /**
@@ -77,14 +72,15 @@ public class Junit5TestPlanSupport implements BeforeTestExecutionCallback, After
             throw new RuntimeException("Issue with the context, unable to get the test class/method");
         }
         Description description = Description.createTestDescription(context.getTestClass().get(),
-            context.getDisplayName(), testMethod.getAnnotations());
+                context.getDisplayName(), testMethod.getAnnotations());
         return description;
     }
 
     @Override
     public void testDisabled(ExtensionContext context, Optional<String> reason) {
-        TS.testSystem().addIgnoredTest(getDescription(context).getDisplayName(), reason.orElseGet(
-            () -> "Test Ignored with Ignore or Disabled Annotation"));
+        TS.testSystem().addIgnoredTest(getDescription(context).getDisplayName(),
+                reason.orElseGet(
+                    () -> "Test Ignored with Ignore or Disabled Annotation"));
     }
 
     @Override

--- a/testah-junit/src/main/java/org/testah/framework/testPlan/TestSystem.java
+++ b/testah-junit/src/main/java/org/testah/framework/testPlan/TestSystem.java
@@ -286,7 +286,7 @@ public class TestSystem {
      *
      * @return the test plan thread local
      */
-    protected ThreadLocal<TestPlanDto> getTestPlanThreadLocal() {
+    public ThreadLocal<TestPlanDto> getTestPlanThreadLocal() {
         if (null == testPlan) {
             testPlan = new ThreadLocal<>();
         }
@@ -305,7 +305,7 @@ public class TestSystem {
      *
      * @param status the status
      */
-    protected void stopTestCase(final Boolean status) {
+    public void stopTestCase(final Boolean status) {
         if (null != getTestCase()) {
             stopTestStep();
             getTestPlan().addTestCase(getTestCase().stop(status));
@@ -315,7 +315,7 @@ public class TestSystem {
     /**
      * Stop test step.
      */
-    protected void stopTestStep() {
+    public void stopTestStep() {
         if (null != getTestStep()) {
             getTestCase().addTestStep(getTestStep().stop());
             testStep.set(null);
@@ -428,7 +428,7 @@ public class TestSystem {
      *
      * @param testPlanStart the new test plan start
      */
-    protected void setTestPlanStart(final boolean testPlanStart) {
+    public void setTestPlanStart(final boolean testPlanStart) {
         this.testPlanStart.set(testPlanStart);
     }
 
@@ -437,7 +437,7 @@ public class TestSystem {
      *
      * @return true, if successful
      */
-    protected boolean didTestPlanStart() {
+    public boolean didTestPlanStart() {
         if (null == testPlanStart.get()) {
             testPlanStart.set(false);
         }
@@ -449,7 +449,7 @@ public class TestSystem {
      *
      * @return the test case thread local
      */
-    protected ThreadLocal<TestCaseDto> getTestCaseThreadLocal() {
+    public ThreadLocal<TestCaseDto> getTestCaseThreadLocal() {
         if (null == testCase) {
             testCase = new ThreadLocal<>();
         }

--- a/testah-junit/src/main/java/org/testah/framework/testPlan/TestSystem.java
+++ b/testah-junit/src/main/java/org/testah/framework/testPlan/TestSystem.java
@@ -84,7 +84,8 @@ public class TestSystem {
      */
     public void starting(final Description description) {
         starting(description,
-            TestPlanAnnotationDto.create(DEFAULT_TESTPLAN_JUNIT_VERSION, description.getTestClass().getAnnotation(TestPlan.class)),
+            TestPlanAnnotationDto.create(DEFAULT_TESTPLAN_JUNIT_VERSION, description.getTestClass(),
+                    description.getTestClass().getAnnotation(TestPlan.class)),
             TestCaseAnnotationDto.create(description.getAnnotation(TestCase.class)), DEFAULT_TESTPLAN_JUNIT_VERSION);
     }
 
@@ -472,7 +473,8 @@ public class TestSystem {
      */
     public void filterTest(final Description description) {
         filterTest(description,
-            TestPlanAnnotationDto.create(DEFAULT_TESTPLAN_JUNIT_VERSION, description.getTestClass().getAnnotation(TestPlan.class)),
+            TestPlanAnnotationDto.create(DEFAULT_TESTPLAN_JUNIT_VERSION, description.getTestClass(),
+                    description.getTestClass().getAnnotation(TestPlan.class)),
             TestCaseAnnotationDto.create(description.getAnnotation(TestCase.class)));
     }
 

--- a/testah-junit/src/test/groovy/org/testah/client/dto/TestPlanAnnotationDtoTest.groovy
+++ b/testah-junit/src/test/groovy/org/testah/client/dto/TestPlanAnnotationDtoTest.groovy
@@ -1,10 +1,13 @@
 package org.testah.client.dto
 
 import org.testah.Junit5TestPlan
+import org.testah.TS
 import org.testah.client.enums.TestType
 import org.testah.framework.annotations.TestPlanJUnit5
 import org.testah.framework.dto.TestPlanAnnotationDto
+import org.unitils.reflectionassert.ReflectionComparatorMode
 import spock.lang.Specification
+import spock.lang.Unroll
 
 import java.lang.annotation.Annotation
 
@@ -25,7 +28,7 @@ class TestPlanAnnotationDtoTest extends Specification {
         Annotation annotation = Junit5TestPlan.class.getAnnotation(TestPlanJUnit5.class)
 
         when:
-        TestPlanAnnotationDto dto = TestPlanAnnotationDto.create(annotation)
+        TestPlanAnnotationDto dto = TestPlanAnnotationDto.create(null, annotation)
 
         then:
         dto.name() == 'test plan for junit5 example'
@@ -36,7 +39,7 @@ class TestPlanAnnotationDtoTest extends Specification {
         TestPlanJUnit5 testPlanJunit5 = Junit5TestPlan.class.getAnnotation(TestPlanJUnit5.class)
 
         when:
-        TestPlanAnnotationDto dto = TestPlanAnnotationDto.create(testPlanJunit5)
+        TestPlanAnnotationDto dto = TestPlanAnnotationDto.create(null, testPlanJunit5)
 
         then:
         dto.name() == 'test plan for junit5 example'
@@ -59,5 +62,22 @@ class TestPlanAnnotationDtoTest extends Specification {
         dto.tags() == []
         dto.testType() == TestType.DEFAULT
         dto.owner() == ""
+    }
+
+    @Unroll
+    def "TestCreate TestCaseJunit5 as Annotation"(final String[] array1, final String[] array2, final String[] expectedArray) {
+        when:
+        String[] actualArray = TestPlanAnnotationDto.appendAndDedupArray(array1, array2)
+
+        then:
+        TS.asserts().equalsToWithReflection("Check", actualArray, expectedArray, ReflectionComparatorMode.LENIENT_ORDER)
+
+        where:
+        array1    | array2    | expectedArray
+        []        | []        | []
+        ['test']  | ['test']  | ['test']
+        []        | ['test']  | ['test']
+        ['test']  | []        | ['test']
+        ['test1'] | ['test2'] | ['test1', 'test2']
     }
 }

--- a/testah-junit/src/test/groovy/org/testah/framework/cli/TestFilterTest.groovy
+++ b/testah-junit/src/test/groovy/org/testah/framework/cli/TestFilterTest.groovy
@@ -1,5 +1,9 @@
 package org.testah.framework.cli
 
+import org.junit.After
+import org.testah.Junit4TestPlan
+import org.testah.Junit5TestPlan
+import org.testah.TS
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -18,29 +22,31 @@ class TestFilterTest extends Specification {
         rtn == found
 
         where:
-        tagsFound                        | tagsFilter                 | found
-        ["ACCEPTANCE"]                   | "ACCEPTANCE"               | true
-        ["ACCEPTANCE"]                   | "NOT_FOUND"                | false
-        ["ACCEPTANCE"]                   | "!ACCEPTANCE"              | true
-        ["ACCEPTANCE"]                   | "!NOT_FOUND"               | false
-        ["ACCEPTANCE", "NOT_IN_PROD"]    | "ACCEPTANCE,~NOT_IN_PROD"  | false
-        ["ACCEPTANCE", "NOT_IN_PROD2"]   | "ACCEPTANCE,~NOT_IN_PROD"  | true
-        ["ACCEPTANCE", "NOT_IN_PROD2"]   | "!ACCEPTANCE,~NOT_IN_PROD" | true
-        ["ACCEPTANCE2", "NOT_IN_PROD2"]  | "!ACCEPTANCE,~NOT_IN_PROD" | false
-        ["ACCEPTANCE", "PROD", "TEST"]   | "!ACCEPTANCE,PROD,~TEST"   | false
-        ["ACCEPTANCE", "PROD", "TEST2"]  | "!ACCEPTANCE,PROD,~TEST"   | true
-        ["ACCEPTANCE", "PROD", "TEST2"]  | "!ACCEPTANCE,!PROD,~TEST"  | true
-        ["ACCEPTANCE", "PROD2", "TEST2"] | "!ACCEPTANCE,!PROD,~TEST"  | false
-        ["ACCEPTANCE2", "PROD2"]         | "ACCEPTANCE,~PROD"         | false
-        []                               | "ACCEPTANCE,~PROD"         | false
-        []                               | ""                         | true
-        ["ACCEPTANCE2", "PROD2"]         | ""                         | true
-        ["ACCEPTANCE2", "PROD2"]         | "~PROD2"                   | false
-        ["ACCEPTANCE2", "PROD2"]         | "!PROD2"                   | true
-        ["ACCEPTANCE2", "PROD2"]         | "PROD2"                    | true
-        ["ACCEPTANCE2", "PROD"]          | "~PROD2"                   | true
-        []                               | "PROD2"                    | false
-        []                               | ""                         | true
+        tagsFound                        | tagsFilter                       | found
+        ["ACCEPTANCE"]                   | "ACCEPTANCE"                     | true
+        ["ACCEPTANCE"]                   | "NOT_FOUND"                      | false
+        ["ACCEPTANCE"]                   | "!ACCEPTANCE"                    | true
+        ["ACCEPTANCE"]                   | "!NOT_FOUND"                     | false
+        ["ACCEPTANCE", "NOT_IN_PROD"]    | "ACCEPTANCE,~NOT_IN_PROD"        | false
+        ["ACCEPTANCE", "NOT_IN_PROD2"]   | "ACCEPTANCE,~NOT_IN_PROD"        | true
+        ["ACCEPTANCE", "NOT_IN_PROD2"]   | "!ACCEPTANCE,~NOT_IN_PROD"       | true
+        ["ACCEPTANCE2", "NOT_IN_PROD2"]  | "!ACCEPTANCE,~NOT_IN_PROD"       | false
+        ["ACCEPTANCE", "PROD", "TEST"]   | "!ACCEPTANCE,PROD,~TEST"         | false
+        ["ACCEPTANCE", "PROD", "TEST2"]  | "!ACCEPTANCE,PROD,~TEST"         | true
+        ["ACCEPTANCE", "PROD", "TEST2"]  | "!ACCEPTANCE,!PROD,~TEST"        | true
+        ["ACCEPTANCE", "PROD2", "TEST2"] | "!ACCEPTANCE,!PROD,~TEST"        | false
+        ["ACCEPTANCE2", "PROD2"]         | "ACCEPTANCE,~PROD"               | false
+        []                               | "ACCEPTANCE,~PROD"               | false
+        []                               | ""                               | true
+        ["ACCEPTANCE2", "PROD2"]         | ""                               | true
+        ["ACCEPTANCE2", "PROD2"]         | "~PROD2"                         | false
+        ["ACCEPTANCE2", "PROD2"]         | "!PROD2"                         | true
+        ["ACCEPTANCE2", "PROD2"]         | "PROD2"                          | true
+        ["ACCEPTANCE2", "PROD"]          | "~PROD2"                         | true
+        []                               | "PROD2"                          | false
+        []                               | ""                               | true
+        ['pp']                           | "~zz,~zzz,~SYSTEM,PR,~dd,~ss,pp" | true
+        ['ACCEPTANCE']                   | "~zz,~zzz,~SYSTEM,PR,~dd,~ss,pp" | false
     }
 
     @Unroll
@@ -79,4 +85,53 @@ class TestFilterTest extends Specification {
         "   "      | false
         "test"     | true
     }
+
+    @Unroll
+    def "test is testplan with testcase matching JUnit4"(final String runTypeFilter, final boolean found) {
+
+        given:
+        println 'RunType Used is ' + runTypeFilter
+        TestFilter testFilter = new TestFilter()
+        TS.params().setFilterByRunType(runTypeFilter)
+
+        when:
+        boolean rtn = testFilter.filterTestPlansToRun([Junit4TestPlan] as Set)
+
+        then:
+        rtn == found
+
+        where:
+        runTypeFilter | found
+        "r1"          | true
+        "r2"          | true
+        "r"           | false
+    }
+
+    @Unroll
+    def "test is testplan with testcase matching JUnit5"(final String runTypeFilter, final boolean found) {
+
+        given:
+        println 'RunType Used is ' + runTypeFilter
+        TestFilter testFilter = new TestFilter()
+        TS.params().setFilterByRunType(runTypeFilter)
+
+        when:
+        boolean rtn = testFilter.filterTestPlansToRun([Junit5TestPlan] as Set)
+
+        then:
+        rtn == found
+
+        where:
+        runTypeFilter | found
+        "r1"          | true
+        "r2"          | true
+        "r"           | false
+    }
+
+    @After
+    public void teardown() {
+        TS.params().setFilterByRunType(null)
+    }
+
+
 }

--- a/testah-junit/src/test/java/org/testah/Junit4TestPlan.java
+++ b/testah-junit/src/test/java/org/testah/Junit4TestPlan.java
@@ -1,15 +1,20 @@
 package org.testah;
 
 import org.junit.Test;
+import org.testah.client.enums.TestType;
 import org.testah.framework.annotations.TestCase;
 import org.testah.framework.annotations.TestPlan;
 import org.testah.framework.testPlan.HttpTestPlan;
 
-@TestPlan
+@TestPlan(name = "test plan for junit4 example", components = {"c2"}, platforms = {"p2"},
+        devices = {"d2"}, testType = TestType.AUTOMATED, runTypes = "r2", description = "desc",
+        relatedIds = "i2", relatedLinks = "http://www.testah.com")
 public class Junit4TestPlan extends HttpTestPlan {
 
     @Test
-    @TestCase()
+    @TestCase(name = "test for junit4 example", components = {"c1"}, platforms = {"p1"},
+            devices = {"d1"}, testType = TestType.AUTOMATED, runTypes = "r1", description = "desc",
+            relatedIds = "i1", relatedLinks = "http://www.testah.com")
     public void test() {
         TS.asserts().isTrue(true);
     }

--- a/testah-junit/src/test/java/org/testah/framework/cli/TestFilterPlatformTest.java
+++ b/testah-junit/src/test/java/org/testah/framework/cli/TestFilterPlatformTest.java
@@ -53,9 +53,7 @@ public class TestFilterPlatformTest {
     public void testFilterTestPlanPlatform() {
 
         testFilterMyPlatform(1, 1, 0, 1, TestPlanWithPlatform.class);
-
         testFilterMyPlatform(1, 1, 0, 1, TestPlanWithManyPlatforms.class);
-
         testFilterMyPlatform(5, 5, 3, 2, TestPlanWithPlatform.class, TestPlanWithManyPlatforms.class,
                 TestPlanWithPlatformDefault.class, TestPlanWithPlatformEmpty.class,
                 TestPlanWithPlatformEmptyString.class);

--- a/testah-junit/src/test/java/org/testah/framework/cli/TestFilterPlatformTest.java
+++ b/testah-junit/src/test/java/org/testah/framework/cli/TestFilterPlatformTest.java
@@ -68,19 +68,19 @@ public class TestFilterPlatformTest {
         Set<Class<?>> classes = ImmutableSet.copyOf(Arrays.asList(classesToAdd));
 
         TS.params().setFilterByPlatform(null);
-        Assert.assertEquals(expectedTest1, filter.resetTestClassesMetFilters().filterTestPlansToRun(classes)
+        Assert.assertEquals("Test 1", expectedTest1, filter.resetTestClassesMetFilters().filterTestPlansToRun(classes)
                 .size());
 
         TS.params().setFilterByPlatform("");
-        Assert.assertEquals(expectedTest2, filter.resetTestClassesMetFilters().filterTestPlansToRun(classes)
+        Assert.assertEquals("Test 2",expectedTest2, filter.resetTestClassesMetFilters().filterTestPlansToRun(classes)
                 .size());
 
         TS.params().setFilterByPlatform("~TEST_Platform");
-        Assert.assertEquals(expectedTest3, filter.resetTestClassesMetFilters().filterTestPlansToRun(classes)
+        Assert.assertEquals("Test 3",expectedTest3, filter.resetTestClassesMetFilters().filterTestPlansToRun(classes)
                 .size());
 
         TS.params().setFilterByPlatform("TEST_Platform");
-        Assert.assertEquals(expectedTest4, filter.resetTestClassesMetFilters().filterTestPlansToRun(classes)
+        Assert.assertEquals("Test 4",expectedTest4, filter.resetTestClassesMetFilters().filterTestPlansToRun(classes)
                 .size());
     }
 

--- a/testah-junit/src/test/java/org/testah/framework/cli/TestFilterPlatformTest.java
+++ b/testah-junit/src/test/java/org/testah/framework/cli/TestFilterPlatformTest.java
@@ -70,17 +70,14 @@ public class TestFilterPlatformTest {
         TS.params().setFilterByPlatform(null);
         Assert.assertEquals("Test 1", expectedTest1, filter.resetTestClassesMetFilters().filterTestPlansToRun(classes)
                 .size());
-
         TS.params().setFilterByPlatform("");
-        Assert.assertEquals("Test 2",expectedTest2, filter.resetTestClassesMetFilters().filterTestPlansToRun(classes)
+        Assert.assertEquals("Test 2", expectedTest2, filter.resetTestClassesMetFilters().filterTestPlansToRun(classes)
                 .size());
-
         TS.params().setFilterByPlatform("~TEST_Platform");
-        Assert.assertEquals("Test 3",expectedTest3, filter.resetTestClassesMetFilters().filterTestPlansToRun(classes)
+        Assert.assertEquals("Test 3", expectedTest3, filter.resetTestClassesMetFilters().filterTestPlansToRun(classes)
                 .size());
-
         TS.params().setFilterByPlatform("TEST_Platform");
-        Assert.assertEquals("Test 4",expectedTest4, filter.resetTestClassesMetFilters().filterTestPlansToRun(classes)
+        Assert.assertEquals("Test 4", expectedTest4, filter.resetTestClassesMetFilters().filterTestPlansToRun(classes)
                 .size());
     }
 


### PR DESCRIPTION
When filtering test plans, include the meta data from all test cases to see if the test plan should be included in classes to at least try to run.